### PR TITLE
chore(devland): bump image to sha-fb74822

### DIFF
--- a/components-apps/devland/base/kustomization.yaml
+++ b/components-apps/devland/base/kustomization.yaml
@@ -10,4 +10,4 @@ resources:
 images:
   - name: ghcr.io/pixeljonas/devland-2027
     newName: ghcr.io/pixeljonas/devland-2027
-    digest: sha256:b317644d1b42962eb39d8b04b7a4c9571dd6e3d85cb2fc7f18d825697bb3beec
+    digest: sha256:bc5b5bb17a752dc8b0f0763821356fc66067abb7f3dd688b00ca7416dcb46242


### PR DESCRIPTION
Manual replacement for the automated CI PR, which could no longer target `sakaar-ops` (archived during the GitOps repo consolidation — 3 prior CI runs failed with a 403 pushing there). `devland-2027`'s CI workflow has been fixed to open PRs against `home-ops` going forward; it needs a `HOME_OPS_PAT` repo secret added there before it can run automatically again.

This bumps the deployed image digest to `sha-fb74822`, which includes:
- the nginx internal-port-leak fix (previously undeployed — 3 straight CI failures meant every fix since 2026-07-24 got stuck behind this)
- a branded 404 page, corrected Cache-Control on real routes, translated "Discover" CTA, corrected doag.org contact links, and a few other UX-review fixes

Source: https://github.com/PixelJonas/devland-2027/commit/fb74822488478574347b695d4c3c60ff57f7c82f

Per this repo's CLAUDE.md, auto-sync is disabled for applications — merging this still requires a manual ArgoCD sync to actually take effect on the cluster.