### PR TITLE
Deploy docling-serve to sakaar

### DIFF
--- a/bootstrap/overlays/sakaar/values-apps.yaml
+++ b/bootstrap/overlays/sakaar/values-apps.yaml
@@ -64,6 +64,12 @@ applications:
     source:
       path: components-apps/tax-agent
 
+  docling-serve:
+    annotations:
+      argocd.argoproj.io/sync-wave: "300"
+    source:
+      path: components-apps/docling-serve
+
   vaultwarden:
     annotations:
       argocd.argoproj.io/sync-wave: "300"

--- a/components-apps/docling-serve/docling-serve-app.yaml
+++ b/components-apps/docling-serve/docling-serve-app.yaml
@@ -1,0 +1,88 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "111"
+  name: docling-serve-app
+  namespace: openshift-gitops
+spec:
+  destination:
+    namespace: docling-serve
+    server: "https://kubernetes.default.svc"
+  source:
+    chart: app-template
+    repoURL: https://bjw-s-labs.github.io/helm-charts
+    targetRevision: 4.6.2
+    helm:
+      values: |-
+        controllers:
+          docling-serve:
+            containers:
+              docling-serve:
+                image:
+                  # NOTE: the CPU variant is a separate GHCR repository
+                  # (docling-serve-cpu), not a "-cpu" tag suffix on
+                  # docling-serve as originally assumed — see Task 1 PR
+                  # description for details.
+                  repository: ghcr.io/docling-project/docling-serve-cpu
+                  digest: "sha256:693aa883e999894ae2efdf7acd89d8fc14abddfc0af3b9fcdd42b7c1b23e1d25"
+                  pullPolicy: IfNotPresent
+                env:
+                  DOCLING_SERVE_ENABLE_UI: "false"
+                  DOCLING_SERVE_API_KEY:
+                    valueFrom:
+                      secretKeyRef:
+                        name: docling-serve-credentials
+                        key: DOCLING_SERVE_API_KEY
+                resources:
+                  requests:
+                    cpu: 500m
+                    memory: 2Gi
+                  limits:
+                    cpu: 2000m
+                    memory: 4Gi
+                probes:
+                  liveness:
+                    enabled: true
+                    custom: true
+                    spec:
+                      httpGet:
+                        path: /health
+                        port: 5001
+                      initialDelaySeconds: 30
+                      periodSeconds: 15
+                  readiness:
+                    enabled: true
+                    custom: true
+                    spec:
+                      httpGet:
+                        path: /health
+                        port: 5001
+                      initialDelaySeconds: 10
+                      periodSeconds: 10
+
+        service:
+          docling-serve:
+            controller: docling-serve
+            ports:
+              http:
+                port: 5001
+
+        persistence:
+          docling-cache:
+            enabled: true
+            accessMode: ReadWriteOnce
+            storageClass: lvms-vg1
+            size: 5Gi
+            advancedMounts:
+              docling-serve:
+                docling-serve:
+                  - path: /.cache
+
+  project: cluster-apps
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true
+    automated:
+      prune: true
+      selfHeal: true

--- a/components-apps/docling-serve/external-docling-serve-credentials.yaml
+++ b/components-apps/docling-serve/external-docling-serve-credentials.yaml
@@ -1,0 +1,17 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: docling-serve-credentials
+  namespace: docling-serve
+  annotations:
+    argocd.argoproj.io/sync-wave: "30"
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: doppler-cluster
+  target:
+    name: docling-serve-credentials
+  data:
+    - secretKey: DOCLING_SERVE_API_KEY
+      remoteRef:
+        key: TAXAGENT_DOCLING_SERVE_API_KEY

--- a/components-apps/docling-serve/kustomization.yaml
+++ b/components-apps/docling-serve/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - namespace.yaml
+  - external-docling-serve-credentials.yaml
+  - docling-serve-app.yaml

--- a/components-apps/docling-serve/namespace.yaml
+++ b/components-apps/docling-serve/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+  name: docling-serve


### PR DESCRIPTION
Backs taxbuddy P1-T07 (packages/docling_client + doc-pipeline structure stage).

Deploys `docling-serve` as a new standalone app on sakaar only via the bjw-s
app-template chart, per `docs/adding-apps.md`. Produces a reachable Service
at `http://docling-serve.docling-serve.svc.cluster.local:5001`, authenticated
via header `X-Api-Key: <TAXAGENT_DOCLING_SERVE_API_KEY>`. Later tasks (3, 8)
depend on this URL and header name.

**Deviation from the task brief, worth flagging for Task 3/8 reviewers:**
The brief assumed `ghcr.io/docling-project/docling-serve:latest-cpu` (a
`-cpu` tag suffix). The real CPU-only image lives at a **separate GHCR
repository**, `ghcr.io/docling-project/docling-serve-cpu`, not a tag on
`docling-serve`. `skopeo` wasn't available locally, so I resolved the
digest via the GHCR v2 manifest API directly:

```
ghcr.io/docling-project/docling-serve-cpu@sha256:693aa883e999894ae2efdf7acd89d8fc14abddfc0af3b9fcdd42b7c1b23e1d25
```

(multi-arch index; amd64 + arm64 present). Pinned by digest in
`docling-serve-app.yaml`.

New Doppler secret `TAXAGENT_DOCLING_SERVE_API_KEY` added to the `homelab`/
`home` project/config — the same one that already backs every other
`TAXAGENT_*` key consumed via the `doppler-cluster` ClusterSecretStore
(confirmed live via `secrets_names`, not assumed).

`local.home/values-apps.yaml` intentionally untouched — sakaar-only per
task scope.