### PR TITLE
Wire doc-pipeline worker into tax-agent-app

### DIFF
--- a/components-apps/tax-agent/external-tax-agent-credentials.yaml
+++ b/components-apps/tax-agent/external-tax-agent-credentials.yaml
@@ -27,3 +27,6 @@ spec:
     - secretKey: PAPERLESS_WEBHOOK_SECRET
       remoteRef:
         key: TAXAGENT_PAPERLESS_WEBHOOK_SECRET
+    - secretKey: DOCLING_SERVE_API_KEY
+      remoteRef:
+        key: TAXAGENT_DOCLING_SERVE_API_KEY

--- a/components-apps/tax-agent/tax-agent-app.yaml
+++ b/components-apps/tax-agent/tax-agent-app.yaml
@@ -82,6 +82,62 @@ spec:
                       initialDelaySeconds: 5
                       periodSeconds: 10
 
+          doc-pipeline:
+            replicas: 1
+            containers:
+              doc-pipeline:
+                image:
+                  repository: ghcr.io/pixeljonas/tax-agent/doc_pipeline
+                  digest: "sha256:1fcb0faba6f720aedd3fc4a55f4ec164a90fe4aaa1fa7ef41f9f7336cfe4725e"   # real digest published by tax-agent#5's release run (image tag 1827d83c...); release.yml PR updates this on subsequent builds
+                  pullPolicy: IfNotPresent
+                env:
+                  TZ: Europe/Berlin
+                  DATABASE_URL:
+                    valueFrom:
+                      secretKeyRef:
+                        name: tax-agent-db-connection
+                        key: uri
+                  QUEUE_URL: redis://tax-agent-app-valkey:6379/0
+                  PAPERLESS_URL:
+                    valueFrom:
+                      secretKeyRef:
+                        name: tax-agent-credentials
+                        key: PAPERLESS_URL
+                  PAPERLESS_TOKEN:
+                    valueFrom:
+                      secretKeyRef:
+                        name: tax-agent-credentials
+                        key: PAPERLESS_TOKEN
+                  DOCLING_URL: http://docling-serve-app.docling-serve.svc.cluster.local:5001
+                  DOCLING_SERVE_API_KEY:
+                    valueFrom:
+                      secretKeyRef:
+                        name: tax-agent-credentials
+                        key: DOCLING_SERVE_API_KEY
+                probes:
+                  liveness:
+                    enabled: true
+                    custom: true
+                    spec:
+                      exec:
+                        command:
+                          - python3
+                          - -m
+                          - doc_pipeline.healthcheck
+                      initialDelaySeconds: 15
+                      periodSeconds: 15
+                  readiness:
+                    enabled: true
+                    custom: true
+                    spec:
+                      exec:
+                        command:
+                          - python3
+                          - -m
+                          - doc_pipeline.healthcheck
+                      initialDelaySeconds: 10
+                      periodSeconds: 10
+
           valkey:
             containers:
               valkey:


### PR DESCRIPTION
## Summary

- Adds the `doc-pipeline` controller to `components-apps/tax-agent/tax-agent-app.yaml` — the RQ worker built in tax-agent's P1-T07 (`fetch -> structure` stages), listening on `jobs:documents`.
- Wires it to the real `docling-serve` Service (deployed in home-ops PR #34 / commit `1e533fe`), confirmed live via `oc get svc -n docling-serve` on sakaar: `docling-serve-app.docling-serve.svc.cluster.local:5001` — matches the brief's assumed DNS name exactly.
- Adds `DOCLING_SERVE_API_KEY` to `external-tax-agent-credentials.yaml`, sourced from Doppler key `TAXAGENT_DOCLING_SERVE_API_KEY`.
- Uses the **real** published digest (`sha256:1fcb0faba6f720aedd3fc4a55f4ec164a90fe4aaa1fa7ef41f9f7336cfe4725e`, tag `1827d83c...`) from tax-agent PR #5's release run, rather than a placeholder — that image already exists by the time this PR is open, and using it directly avoids the `ImagePullBackOff` bootstrap gap `ingestion-api`'s very first deploy hit with its `"REPLACED-BY-CI"` placeholder tag.

## Dependency

Depends on `ghcr.io/pixeljonas/tax-agent/doc_pipeline` existing — **it now does**, published by [tax-agent#5](https://github.com/PixelJonas/tax-agent/pull/5) (merged, release run [30167607796](https://github.com/PixelJonas/tax-agent/actions/runs/30167607796) succeeded).

## Test plan

- [x] `oc get svc -n docling-serve` confirms Service name/port used in `DOCLING_URL`
- [x] `TAXAGENT_DOCLING_SERVE_API_KEY` confirmed present in Doppler (`homelab`/`home`, the project the sakaar `doppler-cluster` ClusterSecretStore token actually resolves against — confirmed via already-synced `tax-agent-credentials` keys)
- [ ] CI green
- [ ] ArgoCD sync + `oc get pods -n tax-agent` shows `doc-pipeline` pod `Running`, logs show RQ worker startup banner listening on `jobs:documents`