### PR TITLE
docling-serve: bump memory limit 4Gi->8Gi

### DIFF
--- a/components-apps/docling-serve/docling-serve-app.yaml
+++ b/components-apps/docling-serve/docling-serve-app.yaml
@@ -37,10 +37,15 @@ spec:
                 resources:
                   requests:
                     cpu: 500m
-                    memory: 2Gi
+                    memory: 4Gi
                   limits:
                     cpu: 2000m
-                    memory: 4Gi
+                    # Bumped from 4Gi: OOMKilled on large/complex documents
+                    # (e.g. an 18-page contract, a 5.4MB scanned letter)
+                    # during tax-agent P1-T07's 20-document live
+                    # verification — pod memory climbed to ~3.9Gi before
+                    # each kill. Node has ample headroom (93Gi allocatable).
+                    memory: 8Gi
                 probes:
                   liveness:
                     enabled: true


### PR DESCRIPTION
## Summary
- tax-agent P1-T07's 20-document live verification found docling-serve OOMKilled reproducibly on 2/20 documents (an 18-page rental contract, a 5.4MB scanned insurance letter) — pod memory climbed to ~3.9Gi before each kill, hitting the committed 4Gi limit.
- Node has ample headroom (93Gi allocatable, ~21% cluster-wide utilization currently), so this is a straightforward resource bump, not a capacity constraint requiring further investigation.

## Test plan
- [ ] ArgoCD syncs cleanly, pod restarts with new limits
- [ ] Re-run the 2 previously-OOMKilled documents against the live instance to confirm they now succeed