### PR TITLE
fix(tax-agent): add timeoutSeconds to doc-pipeline exec probes

### DIFF
--- a/components-apps/tax-agent/tax-agent-app.yaml
+++ b/components-apps/tax-agent/tax-agent-app.yaml
@@ -126,6 +126,7 @@ spec:
                           - doc_pipeline.healthcheck
                       initialDelaySeconds: 15
                       periodSeconds: 15
+                      timeoutSeconds: 5
                   readiness:
                     enabled: true
                     custom: true
@@ -137,6 +138,7 @@ spec:
                           - doc_pipeline.healthcheck
                       initialDelaySeconds: 10
                       periodSeconds: 10
+                      timeoutSeconds: 5
 
           valkey:
             containers:


### PR DESCRIPTION
## Summary

Live testing found `doc-pipeline`'s `liveness`/`readiness` exec probes (`python3 -m doc_pipeline.healthcheck`, a Redis ping) don't set `timeoutSeconds` explicitly, so Kubernetes/OpenShift defaults to 1 second. The healthcheck script itself sometimes takes 1.2-2.0s (mostly Python interpreter startup overhead for a one-off `python3 -m` invocation, not the Redis ping itself), meaning the probe can legitimately time out and be marked failed under normal conditions. This risks a crash-loop on a pod that is actually healthy — especially bad while a long-running conversion job (up to the new ~450s timeout, see tax-agent PR for the docling client timeout fix) is in flight, since a killed pod loses in-flight work.

## Fix

Add `timeoutSeconds: 5` to both the `liveness` and `readiness` probe specs for the `doc-pipeline` controller in `components-apps/tax-agent/tax-agent-app.yaml` — comfortable headroom above the observed 1.2-2.0s without masking a genuinely hung process. Scoped to `doc-pipeline` only; `ingestion-api` and `valkey` probes are untouched.

This PR is independent — it does not depend on the tax-agent docling-client timeout PR or the doc_pipeline digest-bump PR that will follow it, and can merge on its own.

## Test plan

- [x] Diff scoped only to the `doc-pipeline` controller's two probe specs
- [ ] ArgoCD sync + live verification that doc-pipeline pod remains healthy during a long-running conversion

🤖 Generated with [Claude Code](https://claude.com/claude-code)