### PR TITLE
tax-agent: wire TAXBUDDY_LLMCLIENT_LITELLM_KEY into doc-pipeline

### DIFF
--- a/components-apps/tax-agent/external-tax-agent-credentials.yaml
+++ b/components-apps/tax-agent/external-tax-agent-credentials.yaml
@@ -30,3 +30,6 @@ spec:
     - secretKey: DOCLING_SERVE_API_KEY
       remoteRef:
         key: TAXAGENT_DOCLING_SERVE_API_KEY
+    - secretKey: TAXBUDDY_LLMCLIENT_LITELLM_KEY
+      remoteRef:
+        key: TAXBUDDY_LLMCLIENT_LITELLM_KEY

--- a/components-apps/tax-agent/tax-agent-app.yaml
+++ b/components-apps/tax-agent/tax-agent-app.yaml
@@ -114,6 +114,11 @@ spec:
                       secretKeyRef:
                         name: tax-agent-credentials
                         key: DOCLING_SERVE_API_KEY
+                  TAXBUDDY_LLMCLIENT_LITELLM_KEY:
+                    valueFrom:
+                      secretKeyRef:
+                        name: tax-agent-credentials
+                        key: TAXBUDDY_LLMCLIENT_LITELLM_KEY
                 probes:
                   liveness:
                     enabled: true


### PR DESCRIPTION
## Summary
- Adds the `TAXBUDDY_LLMCLIENT_LITELLM_KEY` mapping to `external-tax-agent-credentials.yaml` (Doppler secret of the same name already exists in `homelab`/`home`, just never wired into a k8s Secret before).
- Adds the corresponding env var to the `doc-pipeline` controller so `llm_client`'s `LLMConfig`/`llm.yaml` (P1-T09, tax-agent PR #8) can resolve it at runtime.

This closes an infra gap discovered during P1-T09 brainstorming: `llm.yaml` expects `TAXBUDDY_LLMCLIENT_LITELLM_KEY`, but the only LiteLLM key currently wired to the `doc-pipeline` pod (`LITELLM_API_KEY`) comes from an unrelated Doppler secret (`TAXAGENT_DOCPIPELINE_LITELLM_KEY`).

## Test plan
- [x] Diff reviewed against existing `PAPERLESS_URL`/`LITELLM_API_KEY`/`DOCLING_SERVE_API_KEY` entries for consistent shape
- [ ] CI (manifest validation)