### PR TITLE
fix(tax-agent): wire LITELLM_BASE_URL into doc-pipeline container env

### DIFF
--- a/components-apps/tax-agent/tax-agent-app.yaml
+++ b/components-apps/tax-agent/tax-agent-app.yaml
@@ -114,6 +114,11 @@ spec:
                       secretKeyRef:
                         name: tax-agent-credentials
                         key: DOCLING_SERVE_API_KEY
+                  LITELLM_BASE_URL:
+                    valueFrom:
+                      secretKeyRef:
+                        name: tax-agent-credentials
+                        key: LITELLM_BASE_URL
                   TAXBUDDY_LLMCLIENT_LITELLM_KEY:
                     valueFrom:
                       secretKeyRef:


### PR DESCRIPTION
## Summary
- doc-pipeline's `llm.yaml` is being fixed (tax-agent commit `ec07721`) to read its LiteLLM `base_url` from `${LITELLM_BASE_URL}` instead of a hardcoded, now-dead sakaar-cluster hostname (broken since the sakaar → altus migration).
- That env var was already synced into the `tax-agent-credentials` secret (Doppler key `TAXAGENT_LITELLM_BASE_URL`) and wired into `ingestion-api`'s container, but never into `doc-pipeline`'s.
- Without this change, once the tax-agent fix ships, `doc-pipeline` would crash on startup with `environment variable 'LITELLM_BASE_URL' referenced in llm.yaml is not set` instead of silently failing DNS resolution.
- This mirrors the existing `ingestion-api` `LITELLM_BASE_URL` `secretKeyRef` pattern exactly (same secret `tax-agent-credentials`, same key `LITELLM_BASE_URL`).

## Test plan
- [x] `kustomize build components-apps/tax-agent --enable-helm` renders `LITELLM_BASE_URL` correctly into the `doc-pipeline` container spec
- [x] `yamllint components-apps/tax-agent/tax-agent-app.yaml` passes with no errors
- [ ] CI `Validate Manifests` check (note: currently failing on `main` for an unrelated, pre-existing issue — see PR comment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)