### PR TITLE
fix: remove trailing blank line in sakaar overlay (unblocks CI)

### DIFF
--- a/bootstrap/overlays/sakaar/values-apps.yaml
+++ b/bootstrap/overlays/sakaar/values-apps.yaml
@@ -39,4 +39,3 @@ applications:
       argocd.argoproj.io/sync-wave: "200"
     source:
       path: components-apps/cloudnative-pg
-


### PR DESCRIPTION
## Summary
- Pre-existing `Validate Manifests` CI failure on `main` (yamllint `empty-lines: too many blank lines (1 > 0)` at `bootstrap/overlays/sakaar/values-apps.yaml:42`) — a trailing blank line left over from the "chore(immich): remove unused Sakaar overlay" commit.
- Confirmed this is unrelated to any specific feature and was already failing on `main` before this change (verified against `main`'s own recent CI runs).
- Blocking PR #70 (and presumably others) from getting a clean CI signal.

## Test plan
- [x] `yamllint bootstrap/overlays/sakaar/values-apps.yaml` — clean after the fix
- [x] Single-line diff, whitespace-only, no semantic change

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>