### PR TITLE
chore(devland): bump image to sha-154a5b0

### DIFF
--- a/components-apps/devland/base/kustomization.yaml
+++ b/components-apps/devland/base/kustomization.yaml
@@ -10,4 +10,4 @@ resources:
 images:
   - name: ghcr.io/pixeljonas/devland-2027
     newName: ghcr.io/pixeljonas/devland-2027
-    digest: sha256:bded621a1e0a6b7dd381bdf3896debdce70d4b5106f821100a82f1969d5e8020
+    digest: sha256:014225b430405cc5d5f0ca80cae79c72b5d1ca268a89816cb9606142902046eb


### PR DESCRIPTION
Bumps the deployed devland image digest to sha-154a5b0, which includes since the last deploy (sha-107de39):
- Terms-of-use grammar fix (surgical, cross-checked against DE source)
- AI-generation watermark removed from 5 placeholder images
- Merged real, DOAG-shop-sourced content: rebuilt Partner page (real 2027 packages/pricing), real hotel room-block data, new on-site /tickets/ pricing comparison page, Daniel Werth's real confirmed title
- Footer bug fix (empty nav column), Visionary Track day-count/chronology correction
- node_modules/dist fully untracked from the source repo (unrelated to this deploy but landed in the same batch)

Source: https://github.com/PixelJonas/devland-2027/commit/154a5b0acb5f6f8afe0eecc70dabc5b9ff7c1f04