### PR TITLE
feat(taxbuddy): add ARC runner scale-set for taxbuddy

### DIFF
--- a/bootstrap/overlays/sakaar/values-infra.yaml
+++ b/bootstrap/overlays/sakaar/values-infra.yaml
@@ -107,6 +107,14 @@ applications:
     source:
       path: components-infra/gha-runner-scale-set-tax-agent/base
 
+  gha-runner-scale-set-taxbuddy:
+    annotations:
+      argocd.argoproj.io/sync-wave: "3"
+    destination:
+      namespace: arc-runners
+    source:
+      path: components-infra/gha-runner-scale-set-taxbuddy/base
+
   gha-runner-scale-set-devland:
     annotations:
       argocd.argoproj.io/sync-wave: "3"

--- a/components-infra/gha-runner-scale-set-taxbuddy/base/kustomization.yaml
+++ b/components-infra/gha-runner-scale-set-taxbuddy/base/kustomization.yaml
@@ -1,0 +1,16 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+commonAnnotations:
+  argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+
+resources:
+  - privileged-clusterrolebinding.yaml
+
+helmCharts:
+  - name: gha-runner-scale-set
+    repo: oci://ghcr.io/actions/actions-runner-controller-charts
+    version: 0.14.2
+    releaseName: arc-runner-set-taxbuddy
+    namespace: arc-runners
+    valuesFile: values.yaml

--- a/components-infra/gha-runner-scale-set-taxbuddy/base/privileged-clusterrolebinding.yaml
+++ b/components-infra/gha-runner-scale-set-taxbuddy/base/privileged-clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: arc-runner-set-taxbuddy-privileged
+subjects:
+  - kind: ServiceAccount
+    name: arc-runner-set-taxbuddy-gha-rs-no-permission
+    namespace: arc-runners
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:privileged

--- a/components-infra/gha-runner-scale-set-taxbuddy/base/values.yaml
+++ b/components-infra/gha-runner-scale-set-taxbuddy/base/values.yaml
@@ -1,0 +1,21 @@
+githubConfigUrl: "https://github.com/PixelJonas/taxbuddy"
+githubConfigSecret: gha-runners-github-secret
+runnerScaleSetName: "arc-runner-set-taxbuddy"
+minRunners: 0
+maxRunners: 10
+controllerServiceAccount:
+  namespace: actions-runner-system
+  name: arc-gha-rs-controller
+containerMode: {}
+template:
+  spec:
+    containers:
+      - name: runner
+        image: ghcr.io/pixeljonas/sakaar-gha-runner:latest
+        command: ["/home/runner/run.sh"]
+        env:
+          - name: RUNNER_ALLOW_RUNASROOT
+            value: "1"
+        securityContext:
+          privileged: true
+          runAsUser: 0


### PR DESCRIPTION
New runner scale-set registered against the renamed github.com/PixelJonas/taxbuddy repo, on sakaar (matching where every other app's runner infra lives, including the existing tax-agent one). Reuses the shared gha-runners-github-secret — no new GitHub App needed.