### PR TITLE
feat(taxbuddy): add new taxbuddy namespace/app

### DIFF
--- a/bootstrap/overlays/local.home/values-apps.yaml
+++ b/bootstrap/overlays/local.home/values-apps.yaml
@@ -64,6 +64,11 @@ applications:
       argocd.argoproj.io/sync-wave: "300"
     source:
       path: components-apps/tax-agent
+  taxbuddy:
+    annotations:
+      argocd.argoproj.io/sync-wave: "300"
+    source:
+      path: components-apps/taxbuddy
   vaultwarden:
     annotations:
       argocd.argoproj.io/sync-wave: "300"

--- a/components-apps/taxbuddy/anyuid-rolebinding.yaml
+++ b/components-apps/taxbuddy/anyuid-rolebinding.yaml
@@ -1,0 +1,14 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: taxbuddy-anyuid
+  annotations:
+    argocd.argoproj.io/sync-wave: "30"
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: taxbuddy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: "system:openshift:scc:anyuid"

--- a/components-apps/taxbuddy/external-taxbuddy-credentials.yaml
+++ b/components-apps/taxbuddy/external-taxbuddy-credentials.yaml
@@ -1,0 +1,35 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: external-taxbuddy-credentials
+  namespace: taxbuddy
+  annotations:
+    argocd.argoproj.io/sync-wave: "30"
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: doppler-cluster
+  target:
+    name: taxbuddy-credentials
+  data:
+    - secretKey: PAPERLESS_URL
+      remoteRef:
+        key: TAXBUDDY_PAPERLESS_URL
+    - secretKey: PAPERLESS_TOKEN
+      remoteRef:
+        key: TAXBUDDY_PAPERLESS_TOKEN
+    - secretKey: LITELLM_BASE_URL
+      remoteRef:
+        key: TAXBUDDY_LITELLM_BASE_URL
+    - secretKey: LITELLM_API_KEY
+      remoteRef:
+        key: TAXBUDDY_DOCPIPELINE_LITELLM_KEY
+    - secretKey: PAPERLESS_WEBHOOK_SECRET
+      remoteRef:
+        key: TAXBUDDY_PAPERLESS_WEBHOOK_SECRET
+    - secretKey: DOCLING_SERVE_API_KEY
+      remoteRef:
+        key: TAXBUDDY_DOCLING_SERVE_API_KEY
+    - secretKey: TAXBUDDY_LLMCLIENT_LITELLM_KEY
+      remoteRef:
+        key: TAXBUDDY_LLMCLIENT_LITELLM_KEY

--- a/components-apps/taxbuddy/external-taxbuddy-db-connection.yaml
+++ b/components-apps/taxbuddy/external-taxbuddy-db-connection.yaml
@@ -1,0 +1,21 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: taxbuddy-db-connection
+  namespace: taxbuddy
+  annotations:
+    argocd.argoproj.io/sync-wave: "30"
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: doppler-cluster
+  target:
+    name: taxbuddy-db-connection
+    template:
+      engineVersion: v2
+      data:
+        uri: "postgresql+psycopg://taxbuddy:{{ .password }}@taxbuddy-db-rw.taxbuddy.svc:5432/taxbuddy"
+  data:
+    - secretKey: password
+      remoteRef:
+        key: TAXBUDDY_POSTGRES_PASSWORD

--- a/components-apps/taxbuddy/external-taxbuddy-db.yaml
+++ b/components-apps/taxbuddy/external-taxbuddy-db.yaml
@@ -1,0 +1,23 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: taxbuddy-db-app-secret
+  namespace: taxbuddy
+  annotations:
+    argocd.argoproj.io/sync-wave: "30"
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: doppler-cluster
+  target:
+    name: taxbuddy-db-app-secret
+    template:
+      engineVersion: v2
+      type: kubernetes.io/basic-auth
+      data:
+        username: "taxbuddy"
+        password: "{{ .password }}"
+  data:
+    - secretKey: password
+      remoteRef:
+        key: TAXBUDDY_POSTGRES_PASSWORD

--- a/components-apps/taxbuddy/external-taxbuddy-ghcr-pull.yaml
+++ b/components-apps/taxbuddy/external-taxbuddy-ghcr-pull.yaml
@@ -1,0 +1,23 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: taxbuddy-ghcr-pull-secret
+  namespace: taxbuddy
+  annotations:
+    argocd.argoproj.io/sync-wave: "30"
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: doppler-cluster
+  target:
+    name: taxbuddy-ghcr-pull-secret
+    template:
+      engineVersion: v2
+      type: kubernetes.io/dockerconfigjson
+      data:
+        .dockerconfigjson: |
+          {"auths":{"ghcr.io":{"username":"PixelJonas","password":"{{ .token }}","auth":"{{ printf "PixelJonas:%s" .token | b64enc }}"}}}
+  data:
+    - secretKey: token
+      remoteRef:
+        key: TAXBUDDY_GHCR_PULL_TOKEN

--- a/components-apps/taxbuddy/kustomization.yaml
+++ b/components-apps/taxbuddy/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - namespace.yaml
+  - anyuid-rolebinding.yaml
+  - external-taxbuddy-credentials.yaml
+  - external-taxbuddy-db.yaml
+  - external-taxbuddy-db-connection.yaml
+  - external-taxbuddy-ghcr-pull.yaml
+  - postgresql-database.yaml
+  - taxbuddy-app.yaml
+  # networkpolicy.yaml intentionally NOT included, matching tax-agent's own
+  # components-apps/tax-agent/kustomization.yaml — see tax-agent's ADR-007:
+  # OVN-Kubernetes on this cluster doesn't reliably allow NetworkPolicy
+  # egress to the Kubernetes API server. No other app in this repo has one
+  # either.

--- a/components-apps/taxbuddy/namespace.yaml
+++ b/components-apps/taxbuddy/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+  name: taxbuddy

--- a/components-apps/taxbuddy/postgresql-database.yaml
+++ b/components-apps/taxbuddy/postgresql-database.yaml
@@ -1,0 +1,21 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: taxbuddy-db
+  namespace: taxbuddy
+  annotations:
+    argocd.argoproj.io/sync-wave: "100"
+spec:
+  instances: 1
+  enablePDB: false
+  bootstrap:
+    initdb:
+      database: taxbuddy
+      owner: taxbuddy
+      secret:
+        name: taxbuddy-db-app-secret
+      postInitSQL:
+        - CREATE EXTENSION IF NOT EXISTS vector
+  storage:
+    size: 10Gi
+    storageClass: lvms-vg1

--- a/components-apps/taxbuddy/taxbuddy-app.yaml
+++ b/components-apps/taxbuddy/taxbuddy-app.yaml
@@ -1,0 +1,215 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: taxbuddy-app
+  namespace: openshift-gitops
+  annotations:
+    argocd.argoproj.io/sync-wave: "111"
+spec:
+  destination:
+    namespace: taxbuddy
+    server: "https://kubernetes.default.svc"
+  source:
+    chart: app-template
+    repoURL: https://bjw-s-labs.github.io/helm-charts
+    targetRevision: 4.6.2
+    helm:
+      values: |-
+        defaultPodOptions:
+          imagePullSecrets:
+            - name: taxbuddy-ghcr-pull-secret
+
+        controllers:
+          ingestion-api:
+            replicas: 1
+            containers:
+              ingestion-api:
+                image:
+                  repository: ghcr.io/pixeljonas/taxbuddy/ingestion_api
+                  digest: "sha256:0000000000000000000000000000000000000000000000000000000000000"   # PLACEHOLDER — Task 3 / release.yml updates this once real images exist
+                  pullPolicy: IfNotPresent
+                env:
+                  TZ: Europe/Berlin
+                  DATABASE_URL:
+                    valueFrom:
+                      secretKeyRef:
+                        name: taxbuddy-db-connection
+                        key: uri
+                  QUEUE_URL: redis://taxbuddy-app-valkey:6379/0
+                  POLL_INTERVAL: 15m
+                  PAPERLESS_URL:
+                    valueFrom:
+                      secretKeyRef:
+                        name: taxbuddy-credentials
+                        key: PAPERLESS_URL
+                  PAPERLESS_TOKEN:
+                    valueFrom:
+                      secretKeyRef:
+                        name: taxbuddy-credentials
+                        key: PAPERLESS_TOKEN
+                  PAPERLESS_WEBHOOK_SECRET:
+                    valueFrom:
+                      secretKeyRef:
+                        name: taxbuddy-credentials
+                        key: PAPERLESS_WEBHOOK_SECRET
+                  LITELLM_BASE_URL:
+                    valueFrom:
+                      secretKeyRef:
+                        name: taxbuddy-credentials
+                        key: LITELLM_BASE_URL
+                  LITELLM_API_KEY:
+                    valueFrom:
+                      secretKeyRef:
+                        name: taxbuddy-credentials
+                        key: LITELLM_API_KEY
+                probes:
+                  liveness:
+                    enabled: true
+                    custom: true
+                    spec:
+                      httpGet:
+                        path: /healthz
+                        port: 8000
+                      initialDelaySeconds: 10
+                      periodSeconds: 10
+                  readiness:
+                    enabled: true
+                    custom: true
+                    spec:
+                      httpGet:
+                        path: /healthz
+                        port: 8000
+                      initialDelaySeconds: 5
+                      periodSeconds: 10
+
+          doc-pipeline:
+            replicas: 1
+            containers:
+              doc-pipeline:
+                image:
+                  repository: ghcr.io/pixeljonas/taxbuddy/doc_pipeline
+                  digest: "sha256:0000000000000000000000000000000000000000000000000000000000000"   # PLACEHOLDER — Task 3 / release.yml updates this once real images exist
+                  pullPolicy: IfNotPresent
+                env:
+                  TZ: Europe/Berlin
+                  DATABASE_URL:
+                    valueFrom:
+                      secretKeyRef:
+                        name: taxbuddy-db-connection
+                        key: uri
+                  QUEUE_URL: redis://taxbuddy-app-valkey:6379/0
+                  PAPERLESS_URL:
+                    valueFrom:
+                      secretKeyRef:
+                        name: taxbuddy-credentials
+                        key: PAPERLESS_URL
+                  PAPERLESS_TOKEN:
+                    valueFrom:
+                      secretKeyRef:
+                        name: taxbuddy-credentials
+                        key: PAPERLESS_TOKEN
+                  DOCLING_URL: http://docling-serve-app.docling-serve.svc.cluster.local:5001
+                  DOCLING_SERVE_API_KEY:
+                    valueFrom:
+                      secretKeyRef:
+                        name: taxbuddy-credentials
+                        key: DOCLING_SERVE_API_KEY
+                  LITELLM_BASE_URL:
+                    valueFrom:
+                      secretKeyRef:
+                        name: taxbuddy-credentials
+                        key: LITELLM_BASE_URL
+                  TAXBUDDY_LLMCLIENT_LITELLM_KEY:
+                    valueFrom:
+                      secretKeyRef:
+                        name: taxbuddy-credentials
+                        key: TAXBUDDY_LLMCLIENT_LITELLM_KEY
+                probes:
+                  liveness:
+                    enabled: true
+                    custom: true
+                    spec:
+                      exec:
+                        command:
+                          - python3
+                          - -m
+                          - doc_pipeline.healthcheck
+                      initialDelaySeconds: 15
+                      periodSeconds: 15
+                      timeoutSeconds: 5
+                  readiness:
+                    enabled: true
+                    custom: true
+                    spec:
+                      exec:
+                        command:
+                          - python3
+                          - -m
+                          - doc_pipeline.healthcheck
+                      initialDelaySeconds: 10
+                      periodSeconds: 10
+                      timeoutSeconds: 5
+
+          valkey:
+            containers:
+              valkey:
+                image:
+                  repository: valkey/valkey
+                  tag: 8.1.9
+                  pullPolicy: IfNotPresent
+                args:
+                  - valkey-server
+                  - --appendonly
+                  - "yes"
+                probes:
+                  liveness:
+                    enabled: true
+                    custom: true
+                    spec:
+                      exec:
+                        command:
+                          - valkey-cli
+                          - ping
+                      initialDelaySeconds: 10
+                      periodSeconds: 10
+                  readiness:
+                    enabled: true
+                    custom: true
+                    spec:
+                      exec:
+                        command:
+                          - valkey-cli
+                          - ping
+                      initialDelaySeconds: 5
+                      periodSeconds: 5
+
+        service:
+          ingestion-api:
+            controller: ingestion-api
+            ports:
+              http:
+                port: 8000
+          valkey:
+            controller: valkey
+            ports:
+              redis:
+                port: 6379
+
+        persistence:
+          valkey-data:
+            enabled: true
+            accessMode: ReadWriteOnce
+            storageClass: lvms-vg1
+            size: 1Gi
+            advancedMounts:
+              valkey:
+                valkey:
+                  - path: /data
+
+  project: cluster-apps
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true
+    automated:
+      prune: true
+      selfHeal: true


### PR DESCRIPTION
Phase 2 of the tax-agent -> taxbuddy rename (see tax-agent's docs/superpowers/specs/2026-07-28-taxbuddy-rename-design.md). Builds a brand-new taxbuddy namespace/CNPG cluster/secrets/app alongside the untouched existing tax-agent namespace — zero risk to the live system. Image digests are placeholders until Phase 2's Task 3 publishes real images to the new GHCR path; ImagePullBackOff on the new pods until then is expected.