### PR TITLE
feat(taxbuddy): deploy dedicated Hermes instance

### DIFF
--- a/bootstrap/overlays/local.home/values-apps.yaml
+++ b/bootstrap/overlays/local.home/values-apps.yaml
@@ -64,6 +64,11 @@ applications:
       argocd.argoproj.io/sync-wave: "300"
     source:
       path: components-apps/taxbuddy
+  taxbuddy-hermes:
+    annotations:
+      argocd.argoproj.io/sync-wave: "300"
+    source:
+      path: components-apps/taxbuddy-hermes
   vaultwarden:
     annotations:
       argocd.argoproj.io/sync-wave: "300"

--- a/components-apps/taxbuddy-hermes/anyuid-rolebinding.yaml
+++ b/components-apps/taxbuddy-hermes/anyuid-rolebinding.yaml
@@ -1,0 +1,14 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: taxbuddy-hermes-anyuid
+  annotations:
+    argocd.argoproj.io/sync-wave: "30"
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: taxbuddy-hermes
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: "system:openshift:scc:anyuid"

--- a/components-apps/taxbuddy-hermes/external-taxbuddy-hermes-credentials.yaml
+++ b/components-apps/taxbuddy-hermes/external-taxbuddy-hermes-credentials.yaml
@@ -1,0 +1,17 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: external-taxbuddy-hermes-credentials
+  namespace: taxbuddy-hermes
+  annotations:
+    argocd.argoproj.io/sync-wave: "30"
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: doppler-cluster
+  target:
+    name: taxbuddy-hermes-credentials
+  data:
+    - secretKey: LITELLM_API_KEY
+      remoteRef:
+        key: TAXBUDDY_HERMES_LITELLM_KEY

--- a/components-apps/taxbuddy-hermes/kustomization.yaml
+++ b/components-apps/taxbuddy-hermes/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - namespace.yaml
+  - anyuid-rolebinding.yaml
+  - external-taxbuddy-hermes-credentials.yaml
+  - taxbuddy-hermes-config.yaml
+  - taxbuddy-hermes-app.yaml
+  # networkpolicy.yaml intentionally NOT included, matching taxbuddy's own
+  # components-apps/taxbuddy/kustomization.yaml — see taxbuddy's ADR-007:
+  # OVN-Kubernetes on this cluster doesn't reliably allow NetworkPolicy
+  # egress to the Kubernetes API server. No other app in this repo has one
+  # either.

--- a/components-apps/taxbuddy-hermes/namespace.yaml
+++ b/components-apps/taxbuddy-hermes/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+  name: taxbuddy-hermes

--- a/components-apps/taxbuddy-hermes/taxbuddy-hermes-app.yaml
+++ b/components-apps/taxbuddy-hermes/taxbuddy-hermes-app.yaml
@@ -1,0 +1,78 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: taxbuddy-hermes-app
+  namespace: openshift-gitops
+  annotations:
+    argocd.argoproj.io/sync-wave: "111"
+spec:
+  destination:
+    namespace: taxbuddy-hermes
+    server: "https://kubernetes.default.svc"
+  source:
+    chart: app-template
+    repoURL: https://bjw-s-labs.github.io/helm-charts
+    targetRevision: 4.6.2
+    helm:
+      values: |-
+        controllers:
+          hermes:
+            replicas: 1
+            containers:
+              hermes:
+                image:
+                  repository: nousresearch/hermes-agent
+                  tag: v2026.7.7
+                  pullPolicy: IfNotPresent
+                # The image's ENTRYPOINT is a fixed s6-overlay wrapper
+                # (/init main-wrapper.sh); it needs an explicit `gateway
+                # run` argument to boot the long-running gateway process
+                # (confirmed against the image's real docker-run examples
+                # in NousResearch/hermes-agent's docker.md) — the plan's
+                # original draft omitted this and the pod would not have
+                # started the right process without it.
+                args:
+                  - gateway
+                  - run
+                env:
+                  TZ: Europe/Berlin
+                  # HERMES_HOME already defaults to /opt/data in the
+                  # official image (paired with HERMES_WRITE_SAFE_ROOT) —
+                  # set explicitly here for clarity, not because the
+                  # default is wrong. The plan's original HERMES_DATA_DIR
+                  # var does not exist in the real image; corrected here.
+                  HERMES_HOME: /opt/data
+                  LITELLM_API_KEY:
+                    valueFrom:
+                      secretKeyRef:
+                        name: taxbuddy-hermes-credentials
+                        key: LITELLM_API_KEY
+
+        persistence:
+          hermes-data:
+            enabled: true
+            accessMode: ReadWriteOnce
+            storageClass: lvms-vg1
+            size: 2Gi
+            advancedMounts:
+              hermes:
+                hermes:
+                  - path: /opt/data
+          hermes-config:
+            enabled: true
+            type: configMap
+            name: taxbuddy-hermes-config
+            advancedMounts:
+              hermes:
+                hermes:
+                  - path: /opt/data/config.yaml
+                    subPath: config.yaml
+                    readOnly: true
+
+  project: cluster-apps
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true
+    automated:
+      prune: true
+      selfHeal: true

--- a/components-apps/taxbuddy-hermes/taxbuddy-hermes-config.yaml
+++ b/components-apps/taxbuddy-hermes/taxbuddy-hermes-config.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: taxbuddy-hermes-config
+  namespace: taxbuddy-hermes
+data:
+  # NOTE: this config.yaml shape was corrected during Task B's live
+  # verification (2026-07-28) against the real nousresearch/hermes-agent
+  # docs/source (github.com/NousResearch/hermes-agent), which do NOT use a
+  # `providers: {custom: {...}}` map or a `platforms.webhook.enabled` key as
+  # an earlier spike's notes assumed. The real schema is a top-level
+  # `custom_providers` list referenced from `model.provider` as
+  # `custom:<name>`, with `key_env` pointing at a process env var (not a
+  # secret value inlined in config.yaml) for the API key. Webhook platform
+  # is opt-in via the WEBHOOK_ENABLED env var (default off), so it is
+  # simply left unset here rather than toggled in config.yaml.
+  config.yaml: |
+    model:
+      default: claude-sonnet-5
+      provider: custom:litellm
+    custom_providers:
+      - name: litellm
+        base_url: http://litellm-app.litellm.svc:4000/v1
+        key_env: LITELLM_API_KEY


### PR DESCRIPTION
Minimal, kanban-relay-only Hermes instance for the taxbuddy approval inbox (P1-T12a) — see taxbuddy's `docs/superpowers/specs/2026-07-28-dedicated-hermes-instance-design.md`. Isolated from the owner's personal Hermes instances per their explicit request. No webhook platform, no general coding capability — just what `agent_runtime`'s existing oc-exec-based kanban integration needs.

Note: the config.yaml shape (custom_providers/key_env), the `gateway run` startup args, and the `HERMES_HOME` data-dir env var were corrected against the real `nousresearch/hermes-agent` docs/Dockerfile during this PR's preparation — the plan's original draft config (`HERMES_DATA_DIR`, `providers: {custom: {...}}`) was best-effort from an earlier spike and did not match the actual image. Live pod/PVC/CLI verification to follow after merge.