### PR TITLE
feat(taxbuddy): deploy agent_runtime, wire to dedicated Hermes

### DIFF
--- a/components-apps/taxbuddy/agent-runtime-hermes-exec-rbac.yaml
+++ b/components-apps/taxbuddy/agent-runtime-hermes-exec-rbac.yaml
@@ -1,0 +1,43 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: taxbuddy-agent-runtime-hermes-exec
+  namespace: taxbuddy-hermes
+  annotations:
+    argocd.argoproj.io/sync-wave: "30"
+rules:
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - ""
+    resources:
+      - pods/exec
+    verbs:
+      - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: taxbuddy-agent-runtime-hermes-exec
+  namespace: taxbuddy-hermes
+  annotations:
+    argocd.argoproj.io/sync-wave: "30"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: taxbuddy-agent-runtime-hermes-exec
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: taxbuddy

--- a/components-apps/taxbuddy/kustomization.yaml
+++ b/components-apps/taxbuddy/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 resources:
   - namespace.yaml
   - anyuid-rolebinding.yaml
+  - agent-runtime-hermes-exec-rbac.yaml
   - external-taxbuddy-credentials.yaml
   - external-taxbuddy-db.yaml
   - external-taxbuddy-db-connection.yaml

--- a/components-apps/taxbuddy/taxbuddy-app.yaml
+++ b/components-apps/taxbuddy/taxbuddy-app.yaml
@@ -150,6 +150,54 @@ spec:
                       periodSeconds: 10
                       timeoutSeconds: 5
 
+          agent-runtime:
+            replicas: 1
+            containers:
+              agent-runtime:
+                image:
+                  repository: ghcr.io/pixeljonas/taxbuddy/agent_runtime
+                  digest: "sha256:ca19081558f2168d481ae5ed353b2ba3575f641e2a8950044fbbdf876cd60108"
+                  pullPolicy: IfNotPresent
+                env:
+                  TZ: Europe/Berlin
+                  AGENT_RUNTIME: hermes
+                  DATABASE_URL:
+                    valueFrom:
+                      secretKeyRef:
+                        name: taxbuddy-db-connection
+                        key: uri
+                  PAPERLESS_URL:
+                    valueFrom:
+                      secretKeyRef:
+                        name: taxbuddy-credentials
+                        key: PAPERLESS_URL
+                  PAPERLESS_TOKEN:
+                    valueFrom:
+                      secretKeyRef:
+                        name: taxbuddy-credentials
+                        key: PAPERLESS_TOKEN
+                  HERMES_NAMESPACE: taxbuddy-hermes
+                  HERMES_DEPLOYMENT: taxbuddy-hermes-app
+                probes:
+                  liveness:
+                    enabled: true
+                    custom: true
+                    spec:
+                      httpGet:
+                        path: /healthz
+                        port: 8000
+                      initialDelaySeconds: 10
+                      periodSeconds: 10
+                  readiness:
+                    enabled: true
+                    custom: true
+                    spec:
+                      httpGet:
+                        path: /healthz
+                        port: 8000
+                      initialDelaySeconds: 5
+                      periodSeconds: 10
+
           valkey:
             containers:
               valkey:


### PR DESCRIPTION
Replaces closed PR #115 (stale, pre-rename). Deploys agent_runtime's controller into the taxbuddy Application and grants it least-privilege pods/exec RBAC into the new dedicated taxbuddy-hermes namespace (deployed in a prior PR). Closes the loop on the P1-T12a approval inbox for the first time.