### PR TITLE
chore(devland-editor-agent): bump image to sha-b0e0f24

### DIFF
--- a/components-apps/devland-editor-agent/base/kustomization.yaml
+++ b/components-apps/devland-editor-agent/base/kustomization.yaml
@@ -14,4 +14,4 @@ resources:
 images:
   - name: ghcr.io/pixeljonas/devland-editor-agent
     newName: ghcr.io/pixeljonas/devland-editor-agent
-    digest: sha256:813c6af9416350784555da92267cdd14a1391fcca8059dbc8a94d8f764e04a29
+    digest: sha256:57aa04d36f94b5d86086821e5907257cc639d2dc7ea17692f36d2d0e3cd4c4c7


### PR DESCRIPTION
Automated digest bump for the separate-chats-per-editor feature.

Digest: sha256:57aa04d36f94b5d86086821e5907257cc639d2dc7ea17692f36d2d0e3cd4c4c7
Source: https://github.com/PixelJonas/devland-editor-agent/commit/b0e0f249606a856c6fd42ce4ce5f98e6406cc7bb