### PR TITLE
chore(devland-editor-agent): bump image to sha-d605d03

### DIFF
--- a/components-apps/devland-editor-agent/base/kustomization.yaml
+++ b/components-apps/devland-editor-agent/base/kustomization.yaml
@@ -14,4 +14,4 @@ resources:
 images:
   - name: ghcr.io/pixeljonas/devland-editor-agent
     newName: ghcr.io/pixeljonas/devland-editor-agent
-    digest: sha256:57aa04d36f94b5d86086821e5907257cc639d2dc7ea17692f36d2d0e3cd4c4c7
+    digest: sha256:17771ffd80fa387222f331c0953a0105e290eab99e8d0cc9f28dbce9629c70ee


### PR DESCRIPTION
Automated digest bump from devland-editor-agent CI.

Digest: sha256:17771ffd80fa387222f331c0953a0105e290eab99e8d0cc9f28dbce9629c70ee
Source: https://github.com/PixelJonas/devland-editor-agent/commit/d605d03fa2dcd45097fd325e7a21d5034f49c89a