### PR TITLE
chore(devland-editor-agent): bump image to sha-222b728

### DIFF
--- a/components-apps/devland-editor-agent/base/kustomization.yaml
+++ b/components-apps/devland-editor-agent/base/kustomization.yaml
@@ -14,4 +14,4 @@ resources:
 images:
   - name: ghcr.io/pixeljonas/devland-editor-agent
     newName: ghcr.io/pixeljonas/devland-editor-agent
-    digest: sha256:17771ffd80fa387222f331c0953a0105e290eab99e8d0cc9f28dbce9629c70ee
+    digest: sha256:71b580060e92eb8e986de3166f72ab37feb447d068d287c82cb3613dc54e8d57


### PR DESCRIPTION
Automated digest bump from devland-editor-agent CI.

Digest: sha256:71b580060e92eb8e986de3166f72ab37feb447d068d287c82cb3613dc54e8d57
Source: https://github.com/PixelJonas/devland-editor-agent/commit/222b728226d4844d1cdb6cefe298d6f593f91d1e