### PR TITLE
feat(taxbuddy-hermes): expose web dashboard behind basic auth

### DIFF
--- a/components-apps/taxbuddy-hermes/external-taxbuddy-hermes-credentials.yaml
+++ b/components-apps/taxbuddy-hermes/external-taxbuddy-hermes-credentials.yaml
@@ -15,3 +15,6 @@ spec:
     - secretKey: LITELLM_API_KEY
       remoteRef:
         key: TAXBUDDY_HERMES_LITELLM_KEY
+    - secretKey: DASHBOARD_PASSWORD
+      remoteRef:
+        key: TAXBUDDY_HERMES_DASHBOARD_PASSWORD

--- a/components-apps/taxbuddy-hermes/taxbuddy-hermes-app.yaml
+++ b/components-apps/taxbuddy-hermes/taxbuddy-hermes-app.yaml
@@ -74,6 +74,46 @@ spec:
                       secretKeyRef:
                         name: taxbuddy-hermes-credentials
                         key: LITELLM_API_KEY
+              dashboard:
+                # `hermes gateway run` does not start the web dashboard —
+                # confirmed live (2026-07-29) via `hermes dashboard
+                # --status` returning "No hermes dashboard processes
+                # running" while the gateway itself was up. It's a
+                # separate process (`hermes dashboard`, real CLI verified
+                # live: --host/--port/--no-open, default port 9119).
+                # Runs as a second container in the SAME pod as the
+                # gateway (not a separate controller) because the
+                # `hermes-data` PVC is ReadWriteOnce (lvms-vg1 storage
+                # class) — kanban.db and other shared state can only be
+                # mounted by one pod at a time, so both processes must
+                # share this pod.
+                image:
+                  repository: nousresearch/hermes-agent
+                  tag: v2026.7.7
+                  pullPolicy: IfNotPresent
+                args:
+                  - dashboard
+                  - --host
+                  - "0.0.0.0"
+                  - --port
+                  - "9119"
+                  - --no-open
+                env:
+                  TZ: Europe/Berlin
+                  HERMES_HOME: /opt/data
+                  # Real env var names confirmed live by reading
+                  # /opt/hermes/plugins/dashboard_auth/basic/__init__.py
+                  # in the running pod — NOT the DASHBOARD_PASSWORD shape
+                  # the personal hermes-user1/2 instances' secret names
+                  # suggested. `--insecure` is a no-op as of the June 2026
+                  # hardening: a non-loopback bind always requires an
+                  # auth provider.
+                  HERMES_DASHBOARD_BASIC_AUTH_USERNAME: jonas
+                  HERMES_DASHBOARD_BASIC_AUTH_PASSWORD:
+                    valueFrom:
+                      secretKeyRef:
+                        name: taxbuddy-hermes-credentials
+                        key: DASHBOARD_PASSWORD
 
         persistence:
           hermes-data:
@@ -87,6 +127,8 @@ spec:
                   - path: /opt/data
                 init-config:
                   - path: /opt/data
+                dashboard:
+                  - path: /opt/data
           hermes-config:
             enabled: true
             type: configMap
@@ -96,6 +138,27 @@ spec:
                 init-config:
                   - path: /opt/hermes-config-seed
                     readOnly: true
+
+        service:
+          dashboard:
+            controller: hermes
+            ports:
+              http:
+                port: 9119
+
+        ingress:
+          dashboard:
+            enabled: true
+            className: openshift-default
+            annotations:
+              route.openshift.io/termination: "edge"
+            hosts:
+              - host: taxbuddy-hermes.apps.altus.janz.digital
+                paths:
+                  - path: /
+                    service:
+                      identifier: dashboard
+                      port: http
 
   project: cluster-apps
   syncPolicy:


### PR DESCRIPTION
## Summary
- `taxbuddy-hermes` was deliberately CLI-only (ADR-0018) — the owner asked for a real web UI instead of `oc exec` + `hermes kanban` commands to review the approval-inbox
- Adds a `dashboard` container to the **same pod** as the gateway (the `hermes-data` PVC is `ReadWriteOnce`, so it can't be mounted by a separate controller/pod at the same time — confirmed this is the only viable topology)
- Adds a Service + Route at `taxbuddy-hermes.apps.altus.janz.digital`, basic-auth protected

## Verified live before writing this
- `hermes gateway run` does **not** start the dashboard (`hermes dashboard --status` returned no running processes while the gateway was up)
- Real dashboard CLI surface (`--host`/`--port`/`--no-open`, default port 9119) and the real basic-auth env var names (`HERMES_DASHBOARD_BASIC_AUTH_USERNAME`/`_PASSWORD`) confirmed by reading the actual plugin source in the running pod, not guessed — the personal `hermes-user1`/`hermes-user2` instances' `DASHBOARD_PASSWORD`-shaped secret names turned out not to match the real env var names
- New Doppler secret `TAXBUDDY_HERMES_DASHBOARD_PASSWORD` (homelab/home) already created and wired through the existing `external-taxbuddy-hermes-credentials` ExternalSecret

## Test plan
- [x] Both changed files pass `yamllint` standalone
- [x] `kustomize build --enable-helm components-apps/taxbuddy-hermes/` renders without error
- [ ] After merge: confirm the dashboard pod container starts cleanly (web UI build step may take ~30-60s on first boot) and the Route serves a basic-auth prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)