### PR TITLE
chore(devland-editor-agent): bump image to sha-d7527db

### DIFF
--- a/components-apps/devland-editor-agent/base/kustomization.yaml
+++ b/components-apps/devland-editor-agent/base/kustomization.yaml
@@ -14,4 +14,4 @@ resources:
 images:
   - name: ghcr.io/pixeljonas/devland-editor-agent
     newName: ghcr.io/pixeljonas/devland-editor-agent
-    digest: sha256:71b580060e92eb8e986de3166f72ab37feb447d068d287c82cb3613dc54e8d57
+    digest: sha256:056c4725ea01e0f02b7f127a7bfe32e10f979ce787cf14294b49f4f4d179d8c2


### PR DESCRIPTION
Automated digest bump from devland-editor-agent CI.

Digest: sha256:056c4725ea01e0f02b7f127a7bfe32e10f979ce787cf14294b49f4f4d179d8c2
Source: https://github.com/PixelJonas/devland-editor-agent/commit/d7527db3c27380487eac4346b03816dc19a7a61a