### PR TITLE
feat(devland-editor-agent): swap Vertex-direct auth for LiteLLM, SQLite history PVC

### DIFF
--- a/components-apps/devland-editor-agent/base/backup/claude-config/local-secret.yaml
+++ b/components-apps/devland-editor-agent/base/backup/claude-config/local-secret.yaml
@@ -1,7 +1,0 @@
-- op: replace
-  path: /spec/target/name
-  value: restic-config-claude-config
-
-- op: replace
-  path: /spec/data/0/remoteRef/key
-  value: DEVLAND_EDITOR_AGENT_CLAUDE_CONFIG_REST_REPO_LOCAL

--- a/components-apps/devland-editor-agent/base/backup/history-db/kustomization.yaml
+++ b/components-apps/devland-editor-agent/base/backup/history-db/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namePrefix: claude-config-
+namePrefix: history-db-
 namespace: devland
 
 resources:

--- a/components-apps/devland-editor-agent/base/backup/history-db/local-secret.yaml
+++ b/components-apps/devland-editor-agent/base/backup/history-db/local-secret.yaml
@@ -1,0 +1,7 @@
+- op: replace
+  path: /spec/target/name
+  value: restic-config-history-db
+
+- op: replace
+  path: /spec/data/0/remoteRef/key
+  value: DEVLAND_EDITOR_AGENT_HISTORY_DB_REST_REPO_LOCAL

--- a/components-apps/devland-editor-agent/base/backup/history-db/local.yaml
+++ b/components-apps/devland-editor-agent/base/backup/history-db/local.yaml
@@ -1,7 +1,7 @@
 - op: replace
   path: /spec/sourcePVC
-  value: devland-editor-agent-claude-config
+  value: devland-editor-agent-history-db
 
 - op: replace
   path: /spec/restic/repository
-  value: restic-config-claude-config
+  value: restic-config-history-db

--- a/components-apps/devland-editor-agent/base/backup/kustomization.yaml
+++ b/components-apps/devland-editor-agent/base/backup/kustomization.yaml
@@ -3,4 +3,4 @@ kind: Kustomization
 
 resources:
   - ./checkouts
-  - ./claude-config
+  - ./history-db

--- a/components-apps/devland-editor-agent/base/deployment.yaml
+++ b/components-apps/devland-editor-agent/base/deployment.yaml
@@ -37,28 +37,29 @@ spec:
               value: https://github.com/PixelJonas/devland-2027.git
             - name: CHECKOUT_ROOT
               value: /data/checkouts
-            # Persists the Claude Agent SDK's own session/transcript store
-            # (conversation history) so it survives pod restarts/redeploys.
-            # Deliberately its own PVC (claude-config-pvc.yaml), not a
-            # subPath on the checkouts volume: /data/checkouts is mounted at
-            # that PVC's literal root (no subPath of its own), so anything
-            # else placed on the same volume would be visible as a stray
-            # child directory under /data/checkouts too. Backed up via a
-            # pre-change VolumeSnapshot
-            # (devland-editor-agent-checkouts-pre-task0-20260728) taken
-            # before this change shipped.
-            - name: CLAUDE_CONFIG_DIR
-              value: /data/claude-config
-            # Vertex-native Claude auth, reusing litellm's own GCP project —
-            # no separate Anthropic API key. See externalsecret.yaml.
-            - name: CLAUDE_CODE_USE_VERTEX
-              value: "1"
-            - name: ANTHROPIC_VERTEX_PROJECT_ID
-              value: itpc-gcp-global-revenue-claude
-            - name: CLOUD_ML_REGION
-              value: global
-            - name: GOOGLE_APPLICATION_CREDENTIALS
-              value: /secrets/gcp/credentials.json
+            # SQLite conversation-history store (replaces the Agent SDK's own
+            # file-based session store, removed along with the SDK itself —
+            # see devland-editor-agent's LiteLLM migration plan). Its own
+            # dedicated PVC (history-db-pvc.yaml), same rationale as the old
+            # claude-config PVC it replaces: kept off the checkouts volume so
+            # it isn't visible as a stray child directory there.
+            - name: HISTORY_DB_PATH
+              value: /data/history/history.db
+            # LiteLLM OpenAI-compatible endpoint, replacing the direct
+            # Vertex-native Claude auth this app used to hold its own GCP
+            # credential for. Model swappable via LITELLM_MODEL_NAME alone —
+            # a future self-hosted Qwen model needs no app code change, just
+            # a LiteLLM model registration and this env var. See
+            # externalsecret.yaml for LITELLM_API_KEY.
+            - name: LITELLM_BASE_URL
+              value: http://litellm-app.litellm.svc:4000/v1
+            - name: LITELLM_MODEL_NAME
+              value: claude-sonnet-5
+            - name: LITELLM_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: devland-editor-agent-secrets
+                  key: litellm_api_key
             - name: GITHUB_TOKEN
               valueFrom:
                 secretKeyRef:
@@ -74,11 +75,8 @@ spec:
           volumeMounts:
             - name: checkouts
               mountPath: /data/checkouts
-            - name: claude-config
-              mountPath: /data/claude-config
-            - name: gcp-credentials
-              mountPath: /secrets/gcp
-              readOnly: true
+            - name: history-db
+              mountPath: /data/history
             - name: uploads
               mountPath: /data/uploads
           resources:
@@ -104,15 +102,9 @@ spec:
         - name: checkouts
           persistentVolumeClaim:
             claimName: devland-editor-agent-checkouts
-        - name: claude-config
+        - name: history-db
           persistentVolumeClaim:
-            claimName: devland-editor-agent-claude-config
-        - name: gcp-credentials
-          secret:
-            secretName: devland-editor-agent-secrets
-            items:
-              - key: gcp_credentials.json
-                path: credentials.json
+            claimName: devland-editor-agent-history-db
         - name: uploads
           persistentVolumeClaim:
             claimName: devland-uploads

--- a/components-apps/devland-editor-agent/base/externalsecret.yaml
+++ b/components-apps/devland-editor-agent/base/externalsecret.yaml
@@ -10,14 +10,13 @@ spec:
   target:
     name: devland-editor-agent-secrets
   data:
-    # Reuses litellm's own GCP service account for Vertex-native Claude
-    # access (verified working: CLAUDE_CODE_USE_VERTEX=1 against project
-    # itpc-gcp-global-revenue-claude, region "global"). No separate
-    # Anthropic API key/billing — goes through the same GCP billing
-    # relationship litellm's Claude-on-Vertex access already uses.
-    - secretKey: gcp_credentials.json
+    # LiteLLM API key for this app's own OpenAI-compatible access to the
+    # in-cluster LiteLLM proxy (replaces the direct GCP service-account
+    # credential this app used to hold for Vertex-native Claude access —
+    # LiteLLM itself now owns that credential centrally).
+    - secretKey: litellm_api_key
       remoteRef:
-        key: LITELLM_GCP_CREDENTIALS
+        key: DEVLAND_EDITOR_AGENT_LITELLM_API_KEY
     - secretKey: github_token
       remoteRef:
         key: DEVLAND_EDITOR_AGENT_GITHUB_TOKEN

--- a/components-apps/devland-editor-agent/base/history-db-pvc.yaml
+++ b/components-apps/devland-editor-agent/base/history-db-pvc.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: devland-editor-agent-claude-config
+  name: devland-editor-agent-history-db
   namespace: devland
   labels:
     app.kubernetes.io/name: devland-editor-agent

--- a/components-apps/devland-editor-agent/base/kustomization.yaml
+++ b/components-apps/devland-editor-agent/base/kustomization.yaml
@@ -5,7 +5,7 @@ resources:
   - externalsecret.yaml
   - external-ghcr-pull.yaml
   - pvc.yaml
-  - claude-config-pvc.yaml
+  - history-db-pvc.yaml
   - deployment.yaml
   - service.yaml
   - route.yaml


### PR DESCRIPTION
## Summary
- Removes devland-editor-agent's direct GCP service-account credential (Vertex-native Claude auth), replacing it with the existing in-cluster LiteLLM proxy's OpenAI-compatible endpoint. Model is now an env var (`LITELLM_MODEL_NAME`) so a future self-hosted model swap needs no app code change.
- Replaces the Agent SDK's file-based session-store PVC (`claude-config`) with a dedicated PVC for the app's new SQLite conversation-history store, renaming the matching VolSync backup config to match.

Corresponds to the app-side migration merged in `PixelJonas/devland-editor-agent@8df9c22`.

## Depends on
Two new Doppler secrets in `homelab`/`home` before this can deploy cleanly:
- `DEVLAND_EDITOR_AGENT_LITELLM_API_KEY`
- `DEVLAND_EDITOR_AGENT_HISTORY_DB_REST_REPO_LOCAL`

## Test plan
- [x] `kubectl kustomize components-apps/devland-editor-agent/base` renders cleanly, confirmed zero leftover Vertex/claude-config references
- [x] VolSync `history-db` backup resources render correctly
- [ ] Doppler secrets created (blocking merge/deploy)
- [ ] ArgoCD sync succeeds
- [ ] Live smoke test against editor.janz.digital

🤖 Generated with [Claude Code](https://claude.com/claude-code)