### PR TITLE
feat(taxbuddy-hermes,taxbuddy): configure Honcho as memory provider, tax-advisor persona

### DIFF
--- a/components-apps/taxbuddy-hermes/external-taxbuddy-hermes-credentials.yaml
+++ b/components-apps/taxbuddy-hermes/external-taxbuddy-hermes-credentials.yaml
@@ -18,3 +18,6 @@ spec:
     - secretKey: DASHBOARD_PASSWORD
       remoteRef:
         key: TAXBUDDY_HERMES_DASHBOARD_PASSWORD
+    - secretKey: HONCHO_API_KEY
+      remoteRef:
+        key: TAXBUDDY_HERMES_HONCHO_API_KEY

--- a/components-apps/taxbuddy-hermes/taxbuddy-hermes-app.yaml
+++ b/components-apps/taxbuddy-hermes/taxbuddy-hermes-app.yaml
@@ -43,8 +43,14 @@ spec:
                 command:
                   - /bin/sh
                   - -c
+                # Extended (Task 6) to also seed honcho.json and SOUL.md
+                # alongside config.yaml — same one-container, one-seed-step
+                # pattern as before, just a &&-chained shell one-liner.
                 args:
-                  - cp /opt/hermes-config-seed/config.yaml /opt/data/config.yaml
+                  - >-
+                    cp /opt/hermes-config-seed/config.yaml /opt/data/config.yaml &&
+                    cp /opt/hermes-config-seed/honcho.json /opt/data/honcho.json &&
+                    cp /opt/hermes-config-seed/SOUL.md /opt/data/SOUL.md
             containers:
               hermes:
                 image:
@@ -74,6 +80,14 @@ spec:
                       secretKeyRef:
                         name: taxbuddy-hermes-credentials
                         key: LITELLM_API_KEY
+                  # Falls back into honcho.json's HonchoClientConfig when
+                  # honcho.json omits apiKey (Task 6 live finding — see
+                  # taxbuddy-hermes-config.yaml).
+                  HONCHO_API_KEY:
+                    valueFrom:
+                      secretKeyRef:
+                        name: taxbuddy-hermes-credentials
+                        key: HONCHO_API_KEY
               dashboard:
                 # `hermes gateway run` does not start the web dashboard —
                 # confirmed live (2026-07-29) via `hermes dashboard

--- a/components-apps/taxbuddy-hermes/taxbuddy-hermes-config.yaml
+++ b/components-apps/taxbuddy-hermes/taxbuddy-hermes-config.yaml
@@ -22,3 +22,42 @@ data:
       - name: litellm
         base_url: http://litellm-app.litellm.svc:4000/v1
         key_env: LITELLM_API_KEY
+  # Live finding (Task 6 verification, 2026-07-30): Honcho config is NOT
+  # part of config.yaml's schema — it's a separate file read from
+  # $HERMES_HOME/honcho.json, confirmed by reading
+  # /opt/hermes/plugins/memory/honcho/client.py's
+  # HonchoClientConfig.from_global_config() in the running
+  # taxbuddy-hermes-app pod. apiKey is deliberately omitted here and
+  # supplied only via the HONCHO_API_KEY env var/Secret (the client falls
+  # back to that env var when the JSON key is absent), keeping the bearer
+  # credential out of the GitOps-tracked ConfigMap. baseUrl uses
+  # honcho-app-honcho.honcho.svc:8000 (not honcho-app.honcho.svc) because
+  # Honcho's app-template deployment has three controllers (honcho,
+  # deriver, openconcho), which gets it the <release>-<controller>
+  # service-naming form.
+  honcho.json: |
+    {
+      "workspace": "taxbuddy",
+      "peerName": "jjanz",
+      "aiPeer": "taxbuddy-hermes",
+      "baseUrl": "http://honcho-app-honcho.honcho.svc:8000",
+      "environment": "production",
+      "enabled": true
+    }
+  # Live finding (Task 6 verification, 2026-07-30): the tax-advisor persona
+  # is NOT a system_prompt config key — it's a separate plain-text file,
+  # $HERMES_HOME/SOUL.md, confirmed via
+  # /opt/hermes/agent/prompt_builder.py's load_soul_md(), which reads
+  # get_hermes_home() / "SOUL.md" and injects its raw content as identity
+  # context.
+  SOUL.md: |
+    # taxbuddy-hermes
+
+    Du bist ein geduldiger, proaktiver Steuerberater-Assistent für den
+    Eigentümer von taxbuddy. Geh davon aus, dass er keine Vorkenntnisse im
+    deutschen Steuerrecht hat. Stelle konkrete, einfache Fragen zu seinen
+    steuerlich relevanten Umständen (Beschäftigungsart, Homeoffice,
+    Vermietung, Fahrzeugkosten-Methode, Fortbildung, Spenden,
+    außergewöhnliche Belastungen) und halte die Antworten über das
+    Honcho-Memory-Tool (honcho_conclude) aktuell. Frage proaktiv nach, wenn
+    ein Umstand unklar oder veraltet wirkt, statt zu raten.

--- a/components-apps/taxbuddy/external-taxbuddy-credentials.yaml
+++ b/components-apps/taxbuddy/external-taxbuddy-credentials.yaml
@@ -33,3 +33,6 @@ spec:
     - secretKey: TAXBUDDY_LLMCLIENT_LITELLM_KEY
       remoteRef:
         key: TAXBUDDY_LLMCLIENT_LITELLM_KEY
+    - secretKey: HONCHO_API_KEY
+      remoteRef:
+        key: TAXBUDDY_DOCPIPELINE_HONCHO_API_KEY

--- a/components-apps/taxbuddy/taxbuddy-app.yaml
+++ b/components-apps/taxbuddy/taxbuddy-app.yaml
@@ -124,6 +124,22 @@ spec:
                       secretKeyRef:
                         name: taxbuddy-credentials
                         key: TAXBUDDY_LLMCLIENT_LITELLM_KEY
+                  # Required at startup with no default (doc_pipeline's
+                  # Settings.from_env(), per
+                  # services/doc_pipeline/src/doc_pipeline/config.py in the
+                  # taxbuddy repo) — added as part of Task 6 to close the
+                  # home-ops gap left by taxbuddy Task 4's HONCHO_* env
+                  # vars. Same in-cluster Honcho service as
+                  # taxbuddy-hermes's honcho.json (honcho-app-honcho, not
+                  # honcho-app — see taxbuddy-hermes-config.yaml).
+                  HONCHO_BASE_URL: http://honcho-app-honcho.honcho.svc:8000
+                  HONCHO_API_KEY:
+                    valueFrom:
+                      secretKeyRef:
+                        name: taxbuddy-credentials
+                        key: HONCHO_API_KEY
+                  HONCHO_WORKSPACE: taxbuddy
+                  HONCHO_OWNER_PEER_ID: jjanz
                 probes:
                   liveness:
                     enabled: true


### PR DESCRIPTION
Adds Honcho as taxbuddy-hermes's memory provider (dedicated taxbuddy workspace, SOUL.md persona) and wires doc_pipeline's required HONCHO_* env vars (taxbuddy Task 4 dependency), per docs/superpowers/specs/2026-07-30-owner-tax-profile-honcho-design.md in the taxbuddy repo. Corrects the plan's config.yaml/memory_providers assumption after live verification found the real config lives in honcho.json + SOUL.md instead — see the taxbuddy repo's .superpowers/sdd/progress.md Task 6 entry for the full account.