### PR TITLE
fix(devland-editor-agent): use external LiteLLM URL, not in-cluster DNS

### DIFF
--- a/components-apps/devland-editor-agent/base/deployment.yaml
+++ b/components-apps/devland-editor-agent/base/deployment.yaml
@@ -51,8 +51,16 @@ spec:
             # a future self-hosted Qwen model needs no app code change, just
             # a LiteLLM model registration and this env var. See
             # externalsecret.yaml for LITELLM_API_KEY.
+            #
+            # MUST be the external URL, not litellm-app.litellm.svc's
+            # in-cluster DNS: devland-editor-agent runs on the Sakaar
+            # cluster, while litellm-app runs on the separate Altus cluster
+            # — in-cluster Kubernetes service DNS never resolves across
+            # clusters. (Caught post-merge: the in-cluster form was wrongly
+            # assumed from taxbuddy-hermes's config, which — unlike this
+            # app — actually is colocated with litellm-app on Altus.)
             - name: LITELLM_BASE_URL
-              value: http://litellm-app.litellm.svc:4000/v1
+              value: https://litellm.apps.altus.janz.digital/v1
             - name: LITELLM_MODEL_NAME
               value: claude-sonnet-5
             - name: LITELLM_API_KEY


### PR DESCRIPTION
## Summary
Corrects a bug introduced in #205: `LITELLM_BASE_URL` used `litellm-app.litellm.svc:4000` (in-cluster DNS), but `devland-editor-agent` runs on **Sakaar** while `litellm-app` runs on the separate **Altus** cluster. In-cluster service DNS never resolves cross-cluster, so the app couldn't have reached LiteLLM for any real chat request — it would pass liveness/readiness probes (which don't touch LiteLLM) but fail as soon as an editor sent a message.

Caught by checking the live pod state on Sakaar shortly after #205 merged, before any editor hit the bug in practice.

## Test plan
- [x] `kubectl kustomize` renders the corrected external URL
- [x] External URL already confirmed reachable/working (used successfully during LiteLLM key generation for #205's Doppler secrets)
- [ ] Merge and confirm ArgoCD re-syncs the pod with the new env var
- [ ] Live smoke test against editor.janz.digital

🤖 Generated with [Claude Code](https://claude.com/claude-code)