### PR TITLE
fix(docling-serve): use TAXBUDDY_ Doppler key, not stale TAXAGENT_

### DIFF
--- a/components-apps/docling-serve/external-docling-serve-credentials.yaml
+++ b/components-apps/docling-serve/external-docling-serve-credentials.yaml
@@ -14,4 +14,4 @@ spec:
   data:
     - secretKey: DOCLING_SERVE_API_KEY
       remoteRef:
-        key: TAXAGENT_DOCLING_SERVE_API_KEY
+        key: TAXBUDDY_DOCLING_SERVE_API_KEY


### PR DESCRIPTION
## Summary
- `docling-serve`'s ExternalSecret referenced the pre-rename `TAXAGENT_DOCLING_SERVE_API_KEY`, which no longer exists in Doppler after the `taxagent` -> `taxbuddy` rename. This was causing `ArgoCDDegradedAlert` to fire (critical) on both `docling-serve` and the parent `cluster-config-manager` app-of-apps on the altus cluster.
- Points the ExternalSecret at the correct existing key, `TAXBUDDY_DOCLING_SERVE_API_KEY` (verified present in Doppler `homelab`/`home`, matching the sibling `taxbuddy` app's already-working ExternalSecret).

## Test plan
- [x] Verified `TAXBUDDY_DOCLING_SERVE_API_KEY` exists in Doppler and `TAXAGENT_DOCLING_SERVE_API_KEY` does not
- [ ] After merge, confirm ArgoCD auto-syncs and `ArgoCDDegradedAlert` clears for both `docling-serve` and `cluster-config-manager`

🤖 Generated with [Claude Code](https://claude.com/claude-code)