### PR TITLE
feat(sakaar): install Tailscale Kubernetes Operator for private egress to Altus

### DIFF
--- a/bootstrap/overlays/sakaar/values-infra.yaml
+++ b/bootstrap/overlays/sakaar/values-infra.yaml
@@ -131,6 +131,16 @@ applications:
     source:
       path: components-infra/gha-runner-scale-set-devland-editor-agent/base
 
+  tailscale-operator:
+    annotations:
+      argocd.argoproj.io/sync-wave: "3"
+    destination:
+      namespace: tailscale
+    source:
+      path: components-infra/tailscale-operator/base
+    syncOptions:
+      - CreateNamespace=true
+
   devland:
     annotations:
       argocd.argoproj.io/sync-wave: "4"

--- a/components-infra/tailscale-operator/base/externalsecret.yaml
+++ b/components-infra/tailscale-operator/base/externalsecret.yaml
@@ -1,0 +1,18 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: operator-oauth
+  namespace: tailscale
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: doppler-cluster
+  target:
+    name: operator-oauth
+  data:
+    - secretKey: client_id
+      remoteRef:
+        key: TAILSCALE_OPERATOR_OAUTH_CLIENT_ID
+    - secretKey: client_secret
+      remoteRef:
+        key: TAILSCALE_OPERATOR_OAUTH_CLIENT_SECRET

--- a/components-infra/tailscale-operator/base/kustomization.yaml
+++ b/components-infra/tailscale-operator/base/kustomization.yaml
@@ -1,0 +1,16 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+commonAnnotations:
+  argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+
+resources:
+  - externalsecret.yaml
+
+helmCharts:
+  - name: tailscale-operator
+    repo: https://pkgs.tailscale.com/helmcharts
+    version: 1.98.9
+    releaseName: tailscale-operator
+    namespace: tailscale
+    valuesFile: values.yaml

--- a/components-infra/tailscale-operator/base/values.yaml
+++ b/components-infra/tailscale-operator/base/values.yaml
@@ -1,0 +1,14 @@
+# oauth.clientId/clientSecret deliberately left unset — the chart falls
+# back to reading the pre-created `operator-oauth` Secret (externalsecret.yaml)
+# in this namespace, keys client_id/client_secret. Confirmed against the
+# chart's own values.yaml comment: "If unset a Secret named operator-oauth
+# must be precreated."
+operatorConfig:
+  defaultTags:
+    - "tag:k8s-operator"
+
+proxyConfig:
+  # Comma-separated string, NOT a YAML list — confirmed against the chart's
+  # own values.yaml, which differs in format from operatorConfig.defaultTags
+  # above.
+  defaultTags: "tag:k8s"


### PR DESCRIPTION
## Summary
- Installs the Tailscale Kubernetes Operator (chart v1.98.9) on Sakaar, in a new `tailscale` namespace, needed so `devland-editor-agent` pods can privately reach LiteLLM (Altus) via an egress proxy routed through the Synology's Caddy reverse proxy — no public exposure, no SDN changes.
- New `operator-oauth` ExternalSecret sourcing `TAILSCALE_OPERATOR_OAUTH_CLIENT_ID`/`_SECRET` from Doppler (`homelab`/`home`).
- Sakaar-only (`bootstrap/overlays/sakaar/values-infra.yaml`, sync-wave 3, ahead of `devland`/`devland-editor-agent`'s wave 4). Not added to Altus.

See `docs/superpowers/specs/2026-07-31-sakaar-altus-litellm-tailscale-design.md` and `docs/superpowers/plans/2026-07-31-sakaar-altus-litellm-tailscale.md` in `devland-dummy` for the full design/plan.

## Test plan
- [x] `kustomize build --enable-helm` renders cleanly (CRDs, RBAC, Deployment, ExternalSecret)
- [x] ApplicationSet renders the new `tailscale-operator` Application correctly, including `CreateNamespace=true`
- [ ] Operator pod comes up healthy on Sakaar (may need SCC grants — OpenShift compatibility is community-documented, not official)
- [ ] Egress Service (follow-up PR) verified reachable

🤖 Generated with [Claude Code](https://claude.com/claude-code)