### PR TITLE
fix(sakaar): grant anyuid SCC to the Tailscale operator ServiceAccount

### DIFF
--- a/components-infra/tailscale-operator/base/kustomization.yaml
+++ b/components-infra/tailscale-operator/base/kustomization.yaml
@@ -6,6 +6,7 @@ commonAnnotations:
 
 resources:
   - externalsecret.yaml
+  - operator-anyuid-rolebinding.yaml
 
 helmCharts:
   - name: tailscale-operator

--- a/components-infra/tailscale-operator/base/operator-anyuid-rolebinding.yaml
+++ b/components-infra/tailscale-operator/base/operator-anyuid-rolebinding.yaml
@@ -1,0 +1,18 @@
+# Not officially documented by Tailscale — this cluster's OpenShift SCCs
+# reject running as an arbitrary non-root UID for tsnet's own home
+# directory (`mkdir /.config: permission denied`), confirmed empirically
+# against this exact operator version/cluster. Community precedent:
+# https://kubernetes.day/til-troubleshooting-tailscale-operator-pods-forbidden-due-to-security-context-constraints-on-openshift-4-16-4-19/
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: system:openshift:scc:anyuid
+  namespace: tailscale
+subjects:
+  - kind: ServiceAccount
+    name: operator
+    namespace: tailscale
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:anyuid


### PR DESCRIPTION
## Summary
Follow-up to #222. The operator crash-looped on Sakaar with `mkdir /.config: permission denied` — OpenShift's default arbitrary-UID assignment can't write tsnet's home directory. Confirmed empirically and fixed live via `oc adm policy add-scc-to-user anyuid -z operator -n tailscale`; this PR commits that grant as a real manifest so it survives a rebuild instead of being an untracked imperative change.

Not officially documented by Tailscale — matches community reports for OpenShift 4.16-4.19.

## Test plan
- [x] Applied live on Sakaar already — operator is running, authenticated to the tailnet (`tailscale-operator` device confirmed live), ArgoCD shows the Application Synced/Healthy
- [x] This PR just codifies the already-verified-working grant into git

🤖 Generated with [Claude Code](https://claude.com/claude-code)