### PR TITLE
feat(sakaar): add Tailscale egress ProxyGroup+Service for LiteLLM via Synology Caddy

### DIFF
--- a/components-infra/tailscale-operator/base/kustomization.yaml
+++ b/components-infra/tailscale-operator/base/kustomization.yaml
@@ -7,6 +7,7 @@ commonAnnotations:
 resources:
   - externalsecret.yaml
   - operator-anyuid-rolebinding.yaml
+  - litellm-egress.yaml
 
 helmCharts:
   - name: tailscale-operator

--- a/components-infra/tailscale-operator/base/litellm-egress.yaml
+++ b/components-infra/tailscale-operator/base/litellm-egress.yaml
@@ -1,0 +1,26 @@
+apiVersion: tailscale.com/v1alpha1
+kind: ProxyGroup
+metadata:
+  name: egress-proxies
+spec:
+  type: egress
+  replicas: 1
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: litellm-egress
+  namespace: tailscale
+  annotations:
+    # The Synology device serving Caddy (network_mode: host, so it shares
+    # the tailscale-router container's tailnet identity/IP). Confirmed via
+    # `tailscale status --json` against the live tailnet, not guessed.
+    tailscale.com/tailnet-fqdn: "tailscale-router.tailbcdef.ts.net"
+    tailscale.com/proxy-group: "egress-proxies"
+spec:
+  type: ExternalName
+  externalName: "placeholder"
+  ports:
+    - port: 443
+      protocol: TCP
+      name: https


### PR DESCRIPTION
## Summary
Exposes the Synology's tailnet identity (serving Caddy's `litellm.app.janz.digital` vhost) as an in-cluster `litellm-egress` Service via the Tailscale Operator's ProxyGroup egress mode (installed in #222/#226).

Uses ProxyGroup rather than standalone single-proxy mode specifically for its stable ClusterIP — needed so `devland-editor-agent` can keep using the real `litellm.app.janz.digital` hostname (via a follow-up `hostAliases` override to this Service's ClusterIP) rather than the egress Service's own DNS name, which would otherwise present the wrong TLS SNI/Host header to Caddy's vhost routing.

## Test plan
- [x] Renders cleanly (ProxyGroup CRD instance + annotated ExternalName Service)
- [ ] ProxyGroup pod(s) come up healthy (may need the `privileged` SCC grant on the `proxies` ServiceAccount, per the plan's flagged uncertainty — `anyuid` alone fixed the operator itself in #226, but proxy pods may need more for their DNAT/iptables work)
- [ ] Egress path verified reachable from a debug pod

🤖 Generated with [Claude Code](https://claude.com/claude-code)