### PR TITLE
fix(sakaar): grant RBAC the Tailscale egress ProxyGroup needs to become ready

### DIFF
--- a/components-infra/tailscale-operator/base/egress-rbac-fixes.yaml
+++ b/components-infra/tailscale-operator/base/egress-rbac-fixes.yaml
@@ -1,0 +1,76 @@
+# Not documented by Tailscale — discovered empirically bringing up the
+# egress ProxyGroup on this OpenShift cluster.
+#
+# 1) OwnerReferencesPermissionEnforcement admission blocks the operator's
+#    per-proxy config Secret because ProxyGroup-owned StatefulSets/Deployments
+#    set blockOwnerDeletion, which requires update on the */finalizers
+#    subresource — not just CRUD on the resource itself.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: operator-statefulset-finalizers
+  namespace: tailscale
+rules:
+  - apiGroups: ["apps"]
+    resources: ["statefulsets/finalizers", "deployments/finalizers"]
+    verbs: ["update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: operator-statefulset-finalizers
+  namespace: tailscale
+subjects:
+  - kind: ServiceAccount
+    name: operator
+    namespace: tailscale
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: operator-statefulset-finalizers
+---
+# 2) The egress ProxyGroup's proxy pods run with privileged: true (NET_ADMIN/
+# iptables for the egress NAT rules). The ServiceAccount the StatefulSet's
+# pod template actually uses is named after the ProxyGroup itself
+# ("egress-proxies"), NOT the generic "proxies" SA the chart also creates.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: system:openshift:scc:privileged
+  namespace: tailscale
+subjects:
+  - kind: ServiceAccount
+    name: egress-proxies
+    namespace: tailscale
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:privileged
+---
+# 3) OpenShift's RestrictedEndpointsAdmission plugin rejects EndpointSlice
+# writes that reference pod-network IPs (e.g. 10.128.x.x) unless the writer
+# also has update/create on the endpointslices/restricted subresource —
+# separate from the endpointslices CRUD already granted to the operator Role.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: operator-endpointslices-restricted
+  namespace: tailscale
+rules:
+  - apiGroups: ["discovery.k8s.io"]
+    resources: ["endpointslices/restricted"]
+    verbs: ["create", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: operator-endpointslices-restricted
+  namespace: tailscale
+subjects:
+  - kind: ServiceAccount
+    name: operator
+    namespace: tailscale
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: operator-endpointslices-restricted

--- a/components-infra/tailscale-operator/base/kustomization.yaml
+++ b/components-infra/tailscale-operator/base/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - externalsecret.yaml
   - operator-anyuid-rolebinding.yaml
   - litellm-egress.yaml
+  - egress-rbac-fixes.yaml
 
 helmCharts:
   - name: tailscale-operator


### PR DESCRIPTION
## Summary
- Three OpenShift-specific RBAC gaps discovered bringing up the `egress-proxies` ProxyGroup (from PR #227), none documented by Tailscale upstream:
  - `OwnerReferencesPermissionEnforcement` blocks the operator's config Secret write unless it can also `update` `statefulsets/finalizers` and `deployments/finalizers`.
  - The egress proxy pods need the `privileged` SCC, but the StatefulSet's pod template uses a ServiceAccount named after the ProxyGroup itself (`egress-proxies`), not the generic `proxies` SA the chart also creates.
  - `RestrictedEndpointsAdmission` rejects EndpointSlice writes referencing pod-network IPs unless the writer also has `create`/`update` on `endpointslices/restricted`.
- All three were applied live via `oc apply`/`oc adm policy` to unblock the rollout; this PR makes them permanent GitOps-managed manifests.

## Test plan
- [x] Verified live on Sakaar: `egress-proxies-0` pod reaches `1/1 Running`, ProxyGroup status `ProxyGroupReady`, Service status `1 out of 1 replicas are ready to route traffic`
- [x] End-to-end: debug pod in `tailscale` namespace curled `https://litellm.app.janz.digital/health/liveliness` (via `--resolve` to the egress ClusterIP) and got `"I'm alive!"` / HTTP 200
- [x] `kustomize build --enable-helm` renders the new Role/RoleBinding objects correctly