### PR TITLE
fix(sakaar): stop ArgoCD selfHeal from fighting the Tailscale operator's egress Service

### DIFF
--- a/bootstrap/overlays/sakaar/values-infra.yaml
+++ b/bootstrap/overlays/sakaar/values-infra.yaml
@@ -140,6 +140,14 @@ applications:
       path: components-infra/tailscale-operator/base
     syncOptions:
       - CreateNamespace=true
+    extraFields: |
+      ignoreDifferences:
+        - group: ""
+          kind: Service
+          name: litellm-egress
+          namespace: tailscale
+          jsonPointers:
+            - /spec/externalName
 
   devland:
     annotations:


### PR DESCRIPTION
## Summary
- The `litellm-egress` Service's `spec.externalName` is declared as `"placeholder"` in git — the Tailscale operator overwrites it at runtime with the real generated backing Service name once the `egress-proxies` ProxyGroup provisions (confirmed live: `ts-litellm-egress-xddl5.tailscale.svc.cluster.local`).
- The `tailscale-operator` Application has `selfHeal: true` and no `ignoreDifferences`, so ArgoCD was flagging this as permanent drift (`OutOfSync`) and would eventually revert the field back to `"placeholder"` on a future reconcile, breaking the egress path.
- Adds an `ignoreDifferences` entry (via the app-of-apps chart's `extraFields` hook) scoped to just `Service/litellm-egress`'s `/spec/externalName` pointer.

## Test plan
- [x] `kustomize build bootstrap/overlays/sakaar --enable-helm` renders the `ignoreDifferences` block correctly under the `tailscale-operator` Application spec
- [x] Confirmed live: before this fix `oc get application tailscale-operator -n openshift-gitops` reported `OutOfSync` due to exactly this field; egress path itself is healthy and verified end-to-end (see PR #228)