### PR TITLE
feat(sakaar): expose restic-rest-server on the tailnet

### DIFF
--- a/components-infra/restic-rest-server/overlays/sakaar/restic-rest-server.yaml
+++ b/components-infra/restic-rest-server/overlays/sakaar/restic-rest-server.yaml
@@ -38,6 +38,9 @@ spec:
         service:
           restic-rest:
             controller: restic-rest-server
+            annotations:
+              tailscale.com/expose: "true"
+              tailscale.com/hostname: "restic-rest-server"
             ports:
               http:
                 port: 8000


### PR DESCRIPTION
## Summary
- Annotates the existing `restic-rest-server` Service (`components-infra/restic-rest-server/overlays/sakaar`) with `tailscale.com/expose`/`tailscale.com/hostname` so the already-installed tailscale-operator spins up a dedicated tailnet-node proxy in front of it.
- Lets asgard (a Mac outside the cluster, already joined to the same tailnet) reach the same restic-rest-server the Kubernetes apps back up to, for a new Jellyfin backup job — no separate Backblaze bucket/credentials needed.
- No operator/RBAC changes: the tailscale-operator's `IngressClass`, CRDs, and the OpenShift SCC/RBAC grants added for the earlier LiteLLM-egress work (`operator-anyuid-rolebinding.yaml`, `egress-rbac-fixes.yaml`) are operator-scoped already and should cover this new proxy too.

## Test plan
- [x] `kustomize build --enable-helm` on the changed overlay renders cleanly
- [x] `yamllint` on the changed file passes
- [ ] After merge: confirm a new `restic-rest-server` node appears in `tailscale status`
- [ ] After merge: `oc get statefulset -n tailscale` — check the new proxy's pod for any SCC rejection; only add an `anyuid` grant if it actually fails
- [ ] After merge: `curl http://restic-rest-server.<tailnet>.ts.net:8000/` from asgard confirms reachability

🤖 Generated with [Claude Code](https://claude.com/claude-code)