### PR TITLE
fix(tailscale-operator): grant privileged SCC to the shared proxies SA

### DIFF
--- a/components-infra/tailscale-operator/base/kustomization.yaml
+++ b/components-infra/tailscale-operator/base/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - operator-anyuid-rolebinding.yaml
   - litellm-egress.yaml
   - egress-rbac-fixes.yaml
+  - proxies-scc-fix.yaml
 
 helmCharts:
   - name: tailscale-operator

--- a/components-infra/tailscale-operator/base/proxies-scc-fix.yaml
+++ b/components-infra/tailscale-operator/base/proxies-scc-fix.yaml
@@ -1,0 +1,21 @@
+# Same root cause as egress-rbac-fixes.yaml's privileged grant for the
+# egress-proxies SA, hit again bringing up an annotation-based Service
+# exposure (tailscale.com/expose) for restic-rest-server: the operator's
+# per-Service ingress proxy pods also run with privileged: true (tsnet's
+# iptables/NAT setup), and they use the generic "proxies" ServiceAccount
+# (not a ProxyGroup-named one), which had no SCC grant at all — confirmed
+# empirically via the pod's FailedCreate event listing every SCC it was
+# rejected from.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: system:openshift:scc:privileged-proxies
+  namespace: tailscale
+subjects:
+  - kind: ServiceAccount
+    name: proxies
+    namespace: tailscale
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:privileged


### PR DESCRIPTION
## Summary
- Follow-up to #231 (restic-rest-server Tailscale exposure): the operator's per-Service ingress proxy pod failed to schedule entirely (`FailedCreate`, rejected by every SCC including anyuid).
- It needs `privileged` (same root cause as the existing egress-proxies grant — tsnet's iptables/NAT setup) and runs under the generic `proxies` ServiceAccount, which had zero SCC grants.
- This is a shared SA any future `tailscale.com/expose`-annotated Service would also use — flagged and confirmed with the user before granting `privileged` rather than assuming `anyuid` would be enough (it wasn't).

## Test plan
- [x] `kustomize build --enable-helm` renders cleanly, RoleBinding present
- [x] `yamllint` passes
- [x] Applied directly to the live cluster to verify before merging: proxy pod went from `FailedCreate` (152 failed attempts over 14h) to `Running` immediately after the RoleBinding was applied
- [x] Confirmed `restic-rest-server.<tailnet>.ts.net` appears in `tailscale status` and responds correctly (405 on `GET /`, which only accepts `POST` — expected restic-rest-server behavior) when curled from asgard, a separate host on the same tailnet

🤖 Generated with [Claude Code](https://claude.com/claude-code)