### PR TITLE
fix(devland-editor-agent): redirect npm cache off the image's stale UID-owned dir

### DIFF
--- a/components-apps/devland-editor-agent/base/deployment.yaml
+++ b/components-apps/devland-editor-agent/base/deployment.yaml
@@ -95,6 +95,18 @@ spec:
                   key: ntfy_url
             - name: UPLOADS_ROOT
               value: /data/uploads
+            # The runtime image's npm cache ($HOME/.npm) is populated at
+            # build time by the image's own build-stage UID and is only
+            # owner-writable (not group-writable), while this Deployment
+            # sets no fsGroup/runAsUser so OpenShift assigns a different
+            # arbitrary UID per pod — every GitWorkspace.ensureDependencies()
+            # `npm ci` call (i.e. every chat turn against an uncached
+            # checkout) failed with EACCES writing into that stale cache.
+            # Redirecting the cache into the container's writable ephemeral
+            # storage sidesteps the ownership mismatch entirely; losing the
+            # cache across pod restarts only costs one slower `npm ci`.
+            - name: NPM_CONFIG_CACHE
+              value: /tmp/.npm-cache
           volumeMounts:
             - name: checkouts
               mountPath: /data/checkouts


### PR DESCRIPTION
## Summary
- Root cause of "chat completions hang / no progress": every chat message triggers `GitWorkspace.ensureDependencies()`, which runs `npm ci` on first use / lockfile change against the editor's cloned checkout.
- That `npm ci` shares the app's own npm cache (`$HOME/.npm`), baked into the runtime image at build time under UID 1001 with **owner-only** write permissions (no group write bit).
- This Deployment sets no `fsGroup`/`runAsUser`, so OpenShift assigns a different arbitrary UID (`1000930000`, confirmed live) per pod — every `npm ci` call failed with `EACCES` before the request ever reached LiteLLM.
- Fix: `NPM_CONFIG_CACHE=/tmp/.npm-cache` redirects the cache into the container's writable ephemeral storage, sidestepping the ownership mismatch. Cache is lost on pod restart, costing one slower `npm ci` — acceptable tradeoff.
- A complementary image-level fix (removing the stale cache dir at build time so it's recreated fresh by whatever UID runs it) is also landing in devland-editor-agent's own Containerfile.

## Test plan
- [x] Confirmed live: `oc exec` into the running pod as its actual runtime UID and directly triggering `/api/chat` reproduced the exact `EACCES` failure (500, no corresponding request even reaching LiteLLM's logs)
- [x] `kustomize build --enable-helm` renders `NPM_CONFIG_CACHE` correctly
- [ ] After merge: re-trigger a live chat completion and confirm it now reaches LiteLLM and streams a real response