### PR TITLE
chore(devland-editor-agent): bump image to sha-15c1da3

### DIFF
--- a/components-apps/devland-editor-agent/base/kustomization.yaml
+++ b/components-apps/devland-editor-agent/base/kustomization.yaml
@@ -14,4 +14,4 @@ resources:
 images:
   - name: ghcr.io/pixeljonas/devland-editor-agent
     newName: ghcr.io/pixeljonas/devland-editor-agent
-    digest: sha256:1a1ee9567a86bfdae6fe5d3c68e831eeeae1ddd15ccb85d221ae9b658f0acad5
+    digest: sha256:abe0864e0f2f06bde8e1501b1df6e217a4ba5a4581b80603511b43a88a5b4fc2


### PR DESCRIPTION
Automated digest bump from devland-editor-agent CI.

Digest: sha256:abe0864e0f2f06bde8e1501b1df6e217a4ba5a4581b80603511b43a88a5b4fc2
Source: https://github.com/PixelJonas/devland-editor-agent/commit/15c1da398ff1886e8d91c1726e2d268cafd8182d