### PR TITLE
chore(devland-editor-agent): bump image to sha-fcb1994

### DIFF
--- a/components-apps/devland-editor-agent/base/kustomization.yaml
+++ b/components-apps/devland-editor-agent/base/kustomization.yaml
@@ -14,4 +14,4 @@ resources:
 images:
   - name: ghcr.io/pixeljonas/devland-editor-agent
     newName: ghcr.io/pixeljonas/devland-editor-agent
-    digest: sha256:444094586b6bae38723ccd28a686dba761529412c3f4aeb336ef1925019c9f3c
+    digest: sha256:f35ac2cd21b8bece9422ad5462d2b32cb8063ed490f9a51341ac05b6ac66d280


### PR DESCRIPTION
Automated digest bump from devland-editor-agent CI.

Digest: sha256:f35ac2cd21b8bece9422ad5462d2b32cb8063ed490f9a51341ac05b6ac66d280
Source: https://github.com/PixelJonas/devland-editor-agent/commit/fcb1994b33d0b3018fa10137231620631f58c1a7