### PR TITLE
chore(devland-editor-agent): bump image to sha-ef657e9

### DIFF
--- a/components-apps/devland-editor-agent/base/kustomization.yaml
+++ b/components-apps/devland-editor-agent/base/kustomization.yaml
@@ -14,4 +14,4 @@ resources:
 images:
   - name: ghcr.io/pixeljonas/devland-editor-agent
     newName: ghcr.io/pixeljonas/devland-editor-agent
-    digest: sha256:f35ac2cd21b8bece9422ad5462d2b32cb8063ed490f9a51341ac05b6ac66d280
+    digest: sha256:a03d39ee6a26cc40097774873f892850e0cf6d8960d246f4aaca23199f29b4a0


### PR DESCRIPTION
Automated digest bump from devland-editor-agent CI.

Digest: sha256:a03d39ee6a26cc40097774873f892850e0cf6d8960d246f4aaca23199f29b4a0
Source: https://github.com/PixelJonas/devland-editor-agent/commit/ef657e9563fa56d369b258718888a0eae857c63e