### PR TITLE
chore(devland-editor-agent): bump image to sha-7f62b19

### DIFF
--- a/components-apps/devland-editor-agent/base/kustomization.yaml
+++ b/components-apps/devland-editor-agent/base/kustomization.yaml
@@ -14,4 +14,4 @@ resources:
 images:
   - name: ghcr.io/pixeljonas/devland-editor-agent
     newName: ghcr.io/pixeljonas/devland-editor-agent
-    digest: sha256:a03d39ee6a26cc40097774873f892850e0cf6d8960d246f4aaca23199f29b4a0
+    digest: sha256:a04a240d4dff61628eadfffac04009cbd830fa6a4eda5dfc70450efe2c82a7bd


### PR DESCRIPTION
Automated digest bump from devland-editor-agent CI.

Digest: sha256:a04a240d4dff61628eadfffac04009cbd830fa6a4eda5dfc70450efe2c82a7bd
Source: https://github.com/PixelJonas/devland-editor-agent/commit/7f62b196b48aec4e5586e2788c2ae2d22a048216