### PR TITLE
chore(devland-editor-agent): bump image to sha-ddcca1a

### DIFF
--- a/components-apps/devland-editor-agent/base/kustomization.yaml
+++ b/components-apps/devland-editor-agent/base/kustomization.yaml
@@ -14,4 +14,4 @@ resources:
 images:
   - name: ghcr.io/pixeljonas/devland-editor-agent
     newName: ghcr.io/pixeljonas/devland-editor-agent
-    digest: sha256:98b0bee6c0f920578738f739a4a607c506e0e4b439ff2e23d3b2fe614eb2d07b
+    digest: sha256:dd5ff77017a6e0ae8b984892ee7cf51682ea4e49446ec776dd552a711dca3444


### PR DESCRIPTION
Automated digest bump from devland-editor-agent CI.

Digest: sha256:dd5ff77017a6e0ae8b984892ee7cf51682ea4e49446ec776dd552a711dca3444
Source: https://github.com/PixelJonas/devland-editor-agent/commit/ddcca1a40799ab6dd90e280939c2bcd8aa6994d3