### PR TITLE
chore(deps): update vaultwarden/server docker tag to v1.37.1

### DIFF
--- a/components-apps/vaultwarden/vaultwarden.yaml
+++ b/components-apps/vaultwarden/vaultwarden.yaml
@@ -22,7 +22,7 @@ spec:
               vaultwarden:
                 image:
                   repository: vaultwarden/server
-                  tag: 1.37.0
+                  tag: 1.37.1
                   pullPolicy: IfNotPresent
                 env:
                   TZ: Europe/Berlin


### PR DESCRIPTION
## Summary
- Patch bump vaultwarden/server 1.37.0 -> 1.37.1. Supersedes renovate PR #235 (that branch had conflicting overlapping history from other stale Renovate branches, so this is a clean re-application of the same single-line change).

## Test plan
- [x] `kustomize build` validates