### PR TITLE
chore(deps): update redis docker tag to v8.10.0

### DIFF
--- a/components-apps/honcho/honcho-app.yaml
+++ b/components-apps/honcho/honcho-app.yaml
@@ -107,7 +107,7 @@ spec:
               redis:
                 image:
                   repository: redis
-                  tag: 8.8.1
+                  tag: 8.10.0
                   pullPolicy: IfNotPresent
                 probes:
                   liveness:

--- a/components-apps/paperless/paperless-chart-app.yaml
+++ b/components-apps/paperless/paperless-chart-app.yaml
@@ -95,7 +95,7 @@ spec:
               broker:
                 image:
                   repository: redis
-                  tag: 8.8.1
+                  tag: 8.10.0
                   pullPolicy: IfNotPresent
               tika:
                 image:


### PR DESCRIPTION
## Summary
- Minor bump redis 8.8.1 -> 8.10.0 for honcho and paperless. Supersedes renovate PR #236 (stale/conflicting branch history), same content.

## Test plan
- [x] kustomize build validates