### PR TITLE
chore(deps): update actions/checkout to v7 and docker/login-action to v4

### DIFF
--- a/.github/workflows/build-gha-runner-image.yaml
+++ b/.github/workflows/build-gha-runner-image.yaml
@@ -17,10 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Code Checkout
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
 
       - name: Log in to GHCR
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3.7.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f  # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/validate-manifests.yaml
+++ b/.github/workflows/validate-manifests.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Code Checkout
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
       - name: Install yamllint
         run: pip install 'yamllint>=1.25.0'
       - name: Verify Kustomize CLI Installation


### PR DESCRIPTION
## Summary
- Bump actions/checkout v6 -> v7 (both workflows) and docker/login-action v3.7.0 -> v4.6.0 (build-gha-runner-image.yaml). Both are CI-only actions on ubuntu-latest/push-triggered workflows; verified no breaking runner/Node version or input changes apply here.
- Supersedes renovate PRs #12 and #30 (stale/conflicting branch history), same content, bundled since both touch the same file.

## Test plan
- [x] validate CI workflow itself runs green on this PR