### PR TITLE
chore(deps): update valkey/valkey docker tag to v9.1.1

### DIFF
--- a/components-apps/taxbuddy/taxbuddy-app.yaml
+++ b/components-apps/taxbuddy/taxbuddy-app.yaml
@@ -219,7 +219,7 @@ spec:
               valkey:
                 image:
                   repository: valkey/valkey
-                  tag: 8.1.9
+                  tag: 9.1.1
                   pullPolicy: IfNotPresent
                 args:
                   - valkey-server


### PR DESCRIPTION
## Summary
- Major bump valkey/valkey 8.1.9 -> 9.1.1 for taxbuddy's sidecar valkey instance (AOF-persisted, standalone, non-cluster).
- Verified: no RDB/AOF persistence format break for standalone instances, no config-format changes, no commands removed in this range (only previously-deprecated commands un-deprecated). Protocol/client-level fully backward compatible.
- No automated backup exists for this PVC (it's a cache/queue, not source-of-truth data) — acceptable risk given reversibility.
- Supersedes renovate PR #31 (stale/conflicting branch history), same content.

## Test plan
- [x] kustomize build validates