### PR TITLE
chore(deps): update immich monorepo to v3.1.0

### DIFF
--- a/components-apps/immich/immich-chart.yaml
+++ b/components-apps/immich/immich-chart.yaml
@@ -22,7 +22,7 @@ spec:
               server:
                 image:
                   repository: ghcr.io/immich-app/immich-server
-                  tag: v2.7.5
+                  tag: v3.1.0
                   pullPolicy: IfNotPresent
                 env:
                   DB_DATABASE_NAME: immich
@@ -44,7 +44,7 @@ spec:
               machine-learning:
                 image:
                   repository: ghcr.io/immich-app/immich-machine-learning
-                  tag: v2.7.5
+                  tag: v3.1.0
                   pullPolicy: IfNotPresent
                 env:
                   REDIS_HOSTNAME: immich-app-redis.immich.svc.cluster.local


### PR DESCRIPTION
## Summary
- Major bump immich-server/immich-machine-learning v2.7.5 -> v3.1.0.
- Verified: this deployment already runs `ghcr.io/immich-app/postgres:17-vectorchord0.3.0-pgvectors0.3.0`, so the v3 required pgvecto.rs -> VectorChord extension migration is already satisfied — no manual DB extension swap needed.
- No storage-layout changes; DB migrations apply automatically on container start.
- Confirmed fresh automated backups exist before merging (volsync `database-backup`, `database-backup-b2`, `library-backup` all synced within the last 8 hours).
- Note: some mobile-app editor features (recolor/live-photo/local-edit) are temporarily regressed upstream in this release per release notes — cosmetic, not data-affecting.
- Supersedes renovate PR #14 (stale/conflicting branch history), same content.

## Test plan
- [x] kustomize build validates
- [x] Confirmed recent successful volsync backups (DB + library) prior to merge