### PR TITLE
chore(deps): update helm release app-template to v5.0.1

### DIFF
--- a/components-apps/docling-serve/docling-serve-app.yaml
+++ b/components-apps/docling-serve/docling-serve-app.yaml
@@ -12,7 +12,7 @@ spec:
   source:
     chart: app-template
     repoURL: https://bjw-s-labs.github.io/helm-charts
-    targetRevision: 4.6.2
+    targetRevision: 5.0.1
     helm:
       values: |-
         controllers:

--- a/components-apps/honcho/honcho-app.yaml
+++ b/components-apps/honcho/honcho-app.yaml
@@ -12,7 +12,7 @@ spec:
   source:
     chart: app-template
     repoURL: https://bjw-s-labs.github.io/helm-charts
-    targetRevision: 4.6.2
+    targetRevision: 5.0.1
     helm:
       values: |-
 

--- a/components-apps/immich/immich-chart.yaml
+++ b/components-apps/immich/immich-chart.yaml
@@ -12,7 +12,7 @@ spec:
   source:
     chart: app-template
     repoURL: https://bjw-s-labs.github.io/helm-charts
-    targetRevision: 4.6.2
+    targetRevision: 5.0.1
     helm:
       values: |-
 


### PR DESCRIPTION
## Summary
- Major bump of the bjw-s app-template chart 4.6.2 -> 5.0.1 for docling-serve, honcho, and immich (the 3 apps Renovate originally grouped into PR #10).
- Verified via rendered-manifest diff (`kustomize build --enable-helm`) that v5 produces identical output to v4 for these 3 apps' existing values blocks — the only relevant v5 breaking changes (automountServiceAccountToken default flip, rawResources restructuring) aren't used by any of them.
- Other apps still pinned to 4.6.2 are out of scope (not part of the original PR); they'll get their own bump separately.
- Supersedes renovate PR #10 (stale/conflicting branch history), same content.

## Test plan
- [x] kustomize build validates for all 3 apps
- [x] Rendered-manifest diff confirms no unexpected output changes from the chart bump itself