### PR TITLE
fix(ci): broaden yamllint chart-cache ignore to all directories

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -1,9 +1,7 @@
 extends: default
 
 ignore: |
-  bootstrap/base/charts/
-  bootstrap/overlays/local.home/charts/
-  bootstrap/overlays/sakaar/charts/
+  **/charts/
 
 rules:
   comments-indentation: disable


### PR DESCRIPTION
## Summary
- `.yamllint`'s ignore list only excluded `bootstrap/*/charts/`, but any component can end up with a vendored chart cache under its own `charts/` dir once CI runs `kustomize build --enable-helm` (e.g. `components-infra/actions-runner-controller/base/charts/gha-runner-scale-set-controller-0.14.2/`). Those vendored templates contain raw Helm `{{ }}` syntax that isn't valid YAML, which was spuriously failing the required "validate" check on PR #13 for a change unrelated to that chart.
- Replaced the 3 hardcoded bootstrap-only entries with `**/charts/`, matching the pattern `.gitignore` already uses for the same reason.

## Test plan
- [x] CI's `yamllint .` step passes on this branch