### PR TITLE
chore(deps): update nousresearch/hermes-agent docker tag to v2026.7.30

### DIFF
--- a/components-apps/taxbuddy-hermes/taxbuddy-hermes-app.yaml
+++ b/components-apps/taxbuddy-hermes/taxbuddy-hermes-app.yaml
@@ -38,7 +38,7 @@ spec:
               init-config:
                 image:
                   repository: nousresearch/hermes-agent
-                  tag: v2026.7.7
+                  tag: v2026.7.30
                   pullPolicy: IfNotPresent
                 command:
                   - /bin/sh
@@ -55,7 +55,7 @@ spec:
               hermes:
                 image:
                   repository: nousresearch/hermes-agent
-                  tag: v2026.7.7
+                  tag: v2026.7.30
                   pullPolicy: IfNotPresent
                 # The image's ENTRYPOINT is a fixed s6-overlay wrapper
                 # (/init main-wrapper.sh); it needs an explicit `gateway
@@ -103,7 +103,7 @@ spec:
                 # share this pod.
                 image:
                   repository: nousresearch/hermes-agent
-                  tag: v2026.7.7
+                  tag: v2026.7.30
                   pullPolicy: IfNotPresent
                 args:
                   - dashboard


### PR DESCRIPTION
## Summary
- Bump nousresearch/hermes-agent v2026.7.7 -> v2026.7.30 for taxbuddy-hermes (init-config, hermes, and dashboard containers).
- No official changelog exists for this range (upstream rolls it into a future v0.20.0 note), so verified at the code level instead: cloned both tags and diffed the actual config loaders this deployment depends on.
  - `custom_providers`/`model.default`/`model.provider: custom:<name>` handling: unchanged (the config module was split into multiple files but the logic is a byte-identical extraction).
  - `honcho.json` field set (`workspace`/`peerName`/`aiPeer`/`baseUrl`/`environment`/`enabled`) read by `HonchoClientConfig.from_global_config()`: unchanged, only additive optional fields.
  - `SOUL.md` loading path/logic: unchanged.
  - No CLI/entrypoint arg changes.
- The two known upstream config-rewrite regressions cited as a general risk for this project (#40821, #43713) don't apply: #40821 was fixed before v2026.7.7 was even tagged, #43713 only affects multi-profile setups which this deployment doesn't use.
- Supersedes renovate PR #234 (stale/conflicting branch history), same content.

## Test plan
- [x] kustomize build validates
- [x] Code-level diff of upstream config loaders confirms no schema break