### PR TITLE
fix(devland-editor-agent): raise router timeout to survive long agent turns

### DIFF
--- a/components-apps/devland-editor-agent/base/route.yaml
+++ b/components-apps/devland-editor-agent/base/route.yaml
@@ -5,6 +5,15 @@ metadata:
   namespace: devland
   labels:
     app.kubernetes.io/name: devland-editor-agent
+  annotations:
+    # Matches agentSession.ts's STEP_TIMEOUT_MS (570s) -- without this the
+    # router's default server timeout (30s) silently kills the connection
+    # during a long multi-step tool-calling turn whenever the backend goes
+    # 30+s without flushing new bytes, with no error surfaced to either the
+    # app (onError/onFinish never fire) or the client (confirmed live
+    # 2026-08-03: a full multi-step turn completed successfully against
+    # LiteLLM but the assistant's reply was never delivered or persisted).
+    haproxy.router.openshift.io/timeout: 600s
 spec:
   host: editor.janz.digital
   to:


### PR DESCRIPTION
## Summary
- The devland-editor-agent Route had no `haproxy.router.openshift.io/timeout` override, so it ran on the router's default (30s).
- A multi-step tool-calling turn that goes 30+s without flushing new bytes gets its connection silently killed with no error surfaced anywhere.
- Confirmed live on 2026-08-03: LiteLLM completed ~35 successful `chat/completions` calls over 6 minutes for one turn, but the assistant's reply was never delivered to the client or persisted to history — neither `onError` nor `onFinish` fired.
- Raises the timeout to 600s to match `agentSession.ts`'s existing `STEP_TIMEOUT_MS`.

## Test plan
- [ ] ArgoCD syncs the Route annotation change
- [ ] Confirm via `oc get route devland-editor-agent -n devland -o yaml` that the annotation is applied
- [ ] Re-test a long, multi-step chat turn (e.g. the devland.eu research prompt) and confirm it completes and persists instead of silently dying

🤖 Generated with [Claude Code](https://claude.com/claude-code)