### PR TITLE
fix(litellm): raise Route timeout to survive slow-first-token completions

### DIFF
--- a/components-apps/litellm/litellm-app.yaml
+++ b/components-apps/litellm/litellm-app.yaml
@@ -80,6 +80,15 @@ spec:
             className: openshift-default
             annotations:
               route.openshift.io/termination: "edge"
+              # Matches devland-editor-agent's Route timeout (same fix,
+              # applied here too): without this, the default ~30s HAProxy
+              # server timeout can kill a completion call whose first token
+              # is slow to arrive (e.g. a large accumulated tool-call
+              # history needing a long prefill), well before LiteLLM/the
+              # backend model actually fails -- confirmed live 2026-08-03,
+              # a devland-editor-agent turn's step got a 504 from this Route
+              # after ~50 prior tool calls in the same turn.
+              haproxy.router.openshift.io/timeout: 600s
             hosts:
               - host: litellm.apps.altus.janz.digital
                 paths:


### PR DESCRIPTION
## Summary
- Adds `haproxy.router.openshift.io/timeout: 600s` to LiteLLM's OpenShift ingress, same fix already applied to devland-editor-agent's own Route in #258.
- Without it, the default ~30s HAProxy server timeout can kill a completion call whose first token is slow to arrive (e.g. a large accumulated tool-call history needing a long prefill) well before LiteLLM or the backend model actually fails — confirmed live 2026-08-03 against a real devland-editor-agent turn (504 from this Route after ~50 prior tool calls in the same turn).
- This is a stopgap, not a full fix — the underlying growth in prefill time across a long agent turn still needs addressing on the caller side (devland-editor-agent's own message-history handling), tracked separately.

## Test plan
- [ ] `validate` CI check passes
- [ ] After merge, confirm ArgoCD syncs (or apply manually via `oc annotate` if the cluster-wide Route `ignoreDifferences` rule blocks it again, same as #258)
- [ ] Verify live: `oc get route -n litellm -o jsonpath='{.items[0].metadata.annotations.haproxy\.router\.openshift\.io/timeout}'` returns `600s`