### PR TITLE
chore(devland-editor-agent): bump image to sha-949c003

### DIFF
--- a/components-apps/devland-editor-agent/base/kustomization.yaml
+++ b/components-apps/devland-editor-agent/base/kustomization.yaml
@@ -14,4 +14,4 @@ resources:
 images:
   - name: ghcr.io/pixeljonas/devland-editor-agent
     newName: ghcr.io/pixeljonas/devland-editor-agent
-    digest: sha256:979ae365ac85e1086aee0d52535949652dbb510b70e78f62d93ed4db3560d3f9
+    digest: sha256:a057e35d3ba956ad6b5fadc47ab1e664b06f395f375b0fdb8060e94f52bb2bbd


### PR DESCRIPTION
Automated digest bump from devland-editor-agent CI.

Digest: sha256:a057e35d3ba956ad6b5fadc47ab1e664b06f395f375b0fdb8060e94f52bb2bbd
Source: https://github.com/PixelJonas/devland-editor-agent/commit/949c003d59a8d291510af4a36ba651c10502fa6d