### PR TITLE
chore(devland-editor-agent): bump image to sha-7fb12b3

### DIFF
--- a/components-apps/devland-editor-agent/base/kustomization.yaml
+++ b/components-apps/devland-editor-agent/base/kustomization.yaml
@@ -14,4 +14,4 @@ resources:
 images:
   - name: ghcr.io/pixeljonas/devland-editor-agent
     newName: ghcr.io/pixeljonas/devland-editor-agent
-    digest: sha256:bfc47c1f437e0196042e42180a31246d3a1527c5ca083249967bc8b3917d5ceb
+    digest: sha256:b14a82bd322293616d55d0ded80d58fb883a24500d03cd8070dde1cf7bef2d18


### PR DESCRIPTION
Automated digest bump from devland-editor-agent CI.

Digest: sha256:b14a82bd322293616d55d0ded80d58fb883a24500d03cd8070dde1cf7bef2d18
Source: https://github.com/PixelJonas/devland-editor-agent/commit/7fb12b3859dbb5869cee91e8d52c5b60fa0054a9