### PR TITLE
fix(gitops): enable automated sync on honcho-app and immich-app

### DIFF
--- a/components-apps/honcho/honcho-app.yaml
+++ b/components-apps/honcho/honcho-app.yaml
@@ -237,3 +237,6 @@ spec:
   syncPolicy:
     syncOptions:
       - CreateNamespace=true
+    automated:
+      prune: true
+      selfHeal: true

--- a/components-apps/immich/immich-chart.yaml
+++ b/components-apps/immich/immich-chart.yaml
@@ -133,3 +133,10 @@ spec:
             accessMode: ReadWriteOnce
             storageClass: lvms-vg1
             size: 20Gi
+
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true
+    automated:
+      prune: true
+      selfHeal: true


### PR DESCRIPTION
## Summary
- `honcho-app` and `immich-app` were the only two leaf Applications on the Altus cluster with no `syncPolicy.automated` at all — every other app in the fleet has `prune: true, selfHeal: true`.
- Effect: merged Renovate dependency bumps (immich → v3.1.0, redis → v8.10.0, app-template chart → v5.0.1) landed in git on 2026-08-02 but were never deployed, leaving both Applications `OutOfSync`.
- This adds the standard `automated: {prune: true, selfHeal: true}` block to both, matching every other Application in the repo.

## Note
Merging this will immediately trigger ArgoCD to sync both apps to their current git-desired state, including the immich v2.7.5 → v3.1.0 upgrade (already approved/merged via #254, just never deployed).

## Test plan
- [x] `kustomize build components-apps/honcho` succeeds
- [x] `kustomize build components-apps/immich` succeeds
- [ ] After merge: confirm `honcho-app` and `immich-app` show `Synced`/`Healthy` in ArgoCD on Altus

🤖 Generated with [Claude Code](https://claude.com/claude-code)