### PR TITLE
chore(devland-editor-agent): bump image to sha-582b587

### DIFF
--- a/components-apps/devland-editor-agent/base/kustomization.yaml
+++ b/components-apps/devland-editor-agent/base/kustomization.yaml
@@ -14,4 +14,4 @@ resources:
 images:
   - name: ghcr.io/pixeljonas/devland-editor-agent
     newName: ghcr.io/pixeljonas/devland-editor-agent
-    digest: sha256:b14a82bd322293616d55d0ded80d58fb883a24500d03cd8070dde1cf7bef2d18
+    digest: sha256:4caabfa92ec47612d74392888092460268bc8000e2e57a9f82ae7e62f1d6d2dd


### PR DESCRIPTION
Automated digest bump from devland-editor-agent CI.

Digest: sha256:4caabfa92ec47612d74392888092460268bc8000e2e57a9f82ae7e62f1d6d2dd
Source: https://github.com/PixelJonas/devland-editor-agent/commit/582b587d697c34abba3169988c9e57afce65395c