### PR TITLE
feat(devland-editor-agent): add CloudNativePG cluster and activate Mastra agent loop

### DIFF
--- a/components-apps/devland-editor-agent/base/deployment.yaml
+++ b/components-apps/devland-editor-agent/base/deployment.yaml
@@ -95,6 +95,29 @@ spec:
                   key: ntfy_url
             - name: UPLOADS_ROOT
               value: /data/uploads
+            # Mastra agent loop (see devland-editor-agent's Mastra migration
+            # plan, docs/superpowers/plans/2026-08-03-mastra-migration.md).
+            # USE_MASTRA_AGENT gates EditorAgentSession (default, unset)
+            # vs. MastraEditorAgentSession — flipping it to "true" here
+            # switches all editor traffic to the Mastra-based loop.
+            # MASTRA_STORAGE_URL backs Mastra's Memory/Observational Memory
+            # via the devland-editor-agent-db CNPG cluster (postgresql-
+            # database.yaml) — composed from the CNPG-generated read-write
+            # Service DNS name (<cluster-name>-rw, same namespace, no FQDN
+            # needed) and the ExternalSecret-provisioned password. The
+            # generated password (see docs/mastra-evaluation.md's
+            # "Infrastructure placement") deliberately excludes
+            # =, +, / (openssl base64 output stripped of those chars) so it
+            # embeds directly in this URI without percent-encoding.
+            - name: MASTRA_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: devland-editor-agent-db-devland-secret
+                  key: password
+            - name: MASTRA_STORAGE_URL
+              value: postgres://devland_editor_agent:$(MASTRA_DB_PASSWORD)@devland-editor-agent-db-rw:5432/devland_editor_agent
+            - name: USE_MASTRA_AGENT
+              value: "true"
             # The runtime image's npm cache ($HOME/.npm) is populated at
             # build time by the image's own build-stage UID and is only
             # owner-writable (not group-writable), while this Deployment

--- a/components-apps/devland-editor-agent/base/external-devland-editor-agent-db.yaml
+++ b/components-apps/devland-editor-agent/base/external-devland-editor-agent-db.yaml
@@ -1,0 +1,23 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: devland-editor-agent-db-devland-secret
+  namespace: devland
+  annotations:
+    argocd.argoproj.io/sync-wave: "30"
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: doppler-cluster
+  target:
+    name: devland-editor-agent-db-devland-secret
+    template:
+      engineVersion: v2
+      type: kubernetes.io/basic-auth
+      data:
+        username: "devland_editor_agent"
+        password: "{{ .password }}"
+  data:
+    - secretKey: password
+      remoteRef:
+        key: DEVLAND_EDITOR_AGENT_POSTGRES_USER_PASSWORD

--- a/components-apps/devland-editor-agent/base/kustomization.yaml
+++ b/components-apps/devland-editor-agent/base/kustomization.yaml
@@ -4,6 +4,8 @@ kind: Kustomization
 resources:
   - externalsecret.yaml
   - external-ghcr-pull.yaml
+  - external-devland-editor-agent-db.yaml
+  - postgresql-database.yaml
   - pvc.yaml
   - history-db-pvc.yaml
   - deployment.yaml

--- a/components-apps/devland-editor-agent/base/postgresql-database.yaml
+++ b/components-apps/devland-editor-agent/base/postgresql-database.yaml
@@ -1,0 +1,19 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: devland-editor-agent-db
+  namespace: devland
+  annotations:
+    argocd.argoproj.io/sync-wave: "100"
+spec:
+  instances: 1
+  enablePDB: false
+  bootstrap:
+    initdb:
+      database: devland_editor_agent
+      owner: devland_editor_agent
+      secret:
+        name: devland-editor-agent-db-devland-secret
+  storage:
+    storageClass: lvms-vg1
+    size: 8Gi


### PR DESCRIPTION
## Summary
- Adds a `devland-editor-agent-db` CloudNativePG cluster (single instance, `lvms-vg1`), modeled on the existing `litellm-db` pattern.
- Adds the matching ExternalSecret (`doppler-cluster` -> `DEVLAND_EDITOR_AGENT_POSTGRES_USER_PASSWORD`).
- Wires `MASTRA_STORAGE_URL` into the deployment from the new cluster.
- Flips `USE_MASTRA_AGENT=true`, switching all editor traffic to the Mastra-based agent loop built in devland-editor-agent's Mastra migration (`docs/superpowers/plans/2026-08-03-mastra-migration.md`, `docs/mastra-evaluation.md`).

## Context
The Mastra migration (12-task implementation, individually reviewed + a clean final whole-branch review) shipped to `main` with the flag defaulting off, so the deployed image has been running dormant-Mastra-code/unchanged-behavior since. This PR is the actual activation, per the plan's Task 13 (explicit owner go/no-go, not pre-authorized).

## Test plan
- [x] `kustomize build components-apps/devland-editor-agent/base` succeeds cleanly
- [x] `yamllint` clean on all changed files
- [ ] CNPG cluster comes up healthy after ArgoCD sync
- [ ] Pod restarts successfully with new env vars
- [ ] Manual smoke test: a real chat request against the Mastra path

🤖 Generated with [Claude Code](https://claude.com/claude-code)