### PR TITLE
fix(devland-editor-agent): sync Deployment after its new Postgres secret/cluster

### DIFF
--- a/components-apps/devland-editor-agent/base/deployment.yaml
+++ b/components-apps/devland-editor-agent/base/deployment.yaml
@@ -5,6 +5,16 @@ metadata:
   namespace: devland
   labels:
     app.kubernetes.io/name: devland-editor-agent
+  annotations:
+    # Must sync after the CNPG bootstrap secret (wave 30,
+    # external-devland-editor-agent-db.yaml) and the Cluster itself (wave
+    # 100, postgresql-database.yaml) -- this Deployment now references that
+    # secret via MASTRA_STORAGE_URL/MASTRA_DB_PASSWORD. Left unannotated,
+    # ArgoCD defaults it to wave 0 and tries to sync/heal it BEFORE the
+    # secret exists, which deadlocks: the Deployment can't go healthy
+    # without the secret, and ArgoCD won't advance to the secret's wave
+    # until the Deployment is healthy. Confirmed live 2026-08-04.
+    argocd.argoproj.io/sync-wave: "150"
 spec:
   replicas: 1
   selector:


### PR DESCRIPTION
## Summary
Fixes a real ArgoCD sync deadlock discovered live right after merging #266: `deployment.yaml` had no `sync-wave` annotation (defaults to wave 0), so ArgoCD tried to sync/heal it before wave 30 (the new CNPG bootstrap `ExternalSecret`) and wave 100 (the `Cluster` itself) — but the Deployment now depends on that secret via `MASTRA_STORAGE_URL`, so it could never go healthy, and ArgoCD's wave-based sync wouldn't advance past wave 0 until it did.

Confirmed live: new pod stuck in `CreateContainerConfigError`, `ExternalSecret devland-editor-agent-db-devland-secret` and `Cluster devland-editor-agent-db` both `OutOfSync`, ArgoCD's operation state stuck on "waiting for healthy state of apps/Deployment/devland-editor-agent". No outage — the previous pod stayed up throughout.

## Fix
Sets `argocd.argoproj.io/sync-wave: "150"` on the Deployment so the secret and database are created and healthy first.

## Test plan
- [x] `kustomize build` clean
- [x] `yamllint` clean
- [ ] ArgoCD sync completes: ExternalSecret + Cluster + Deployment all Synced/Healthy
- [ ] Pod running with new env vars
- [ ] Manual smoke test against the Mastra path

🤖 Generated with [Claude Code](https://claude.com/claude-code)