### PR TITLE
fix(immich): target immich-app SA in SCC bindings

### DIFF
--- a/components-apps/immich/anyuid-rolebinding.yaml
+++ b/components-apps/immich/anyuid-rolebinding.yaml
@@ -4,7 +4,7 @@ metadata:
   name: immich-anyuid
 subjects:
   - kind: ServiceAccount
-    name: default
+    name: immich-app
     namespace: immich
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/components-apps/immich/privileged-rolebinding.yaml
+++ b/components-apps/immich/privileged-rolebinding.yaml
@@ -4,7 +4,7 @@ metadata:
   name: immich-privileged
 subjects:
   - kind: ServiceAccount
-    name: default
+    name: immich-app
     namespace: immich
 roleRef:
   apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
## Summary
- The app-template v5.0.1 chart creates a dedicated `immich-app` ServiceAccount, but the anyuid/privileged SCC ClusterRoleBindings still referenced the `default` SA.
- This caused the database pod to CrashLoopBackOff after the v3.1.0 sync with `FATAL: data directory "/var/lib/postgresql/data" has wrong ownership` — the Postgres container couldn't run as the required UID without the anyuid SCC.
- Updates both `anyuid-rolebinding.yaml` and `privileged-rolebinding.yaml` to target `immich-app` SA.

## Test plan
- [x] `kustomize build components-apps/immich` succeeds
- [ ] After merge: database pod starts, immich-app-server connects to DB and completes v3 migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)