### PR TITLE
fix(honcho): target honcho-app SA in anyuid SCC binding

### DIFF
--- a/components-apps/honcho/anyuid-rolebinding.yaml
+++ b/components-apps/honcho/anyuid-rolebinding.yaml
@@ -6,7 +6,7 @@ metadata:
     argocd.argoproj.io/sync-wave: "30"
 subjects:
   - kind: ServiceAccount
-    name: default
+    name: honcho-app
     namespace: honcho
 roleRef:
   apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
## Summary
- Same root cause as #268 (immich): app-template v5.0.1 creates a dedicated `honcho-app` ServiceAccount, but the anyuid SCC ClusterRoleBinding still referenced `default`.
- All four honcho deployments (honcho, deriver, redis, openconcho) can't create pods: `provider "anyuid": Forbidden: not usable by user or serviceaccount`.
- Updates `anyuid-rolebinding.yaml` to target `honcho-app` SA.

## Test plan
- [x] `kustomize build components-apps/honcho` succeeds
- [ ] After merge: all honcho pods start and honcho-app shows `Healthy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)