### PR TITLE
feat(charts): bump all app-template charts to v5.0.1, fix SCC SA targets

### DIFF
--- a/components-apps/litellm/anyuid-rolebinding.yaml
+++ b/components-apps/litellm/anyuid-rolebinding.yaml
@@ -6,7 +6,7 @@ metadata:
     argocd.argoproj.io/sync-wave: "30"
 subjects:
   - kind: ServiceAccount
-    name: default
+    name: litellm-app
     namespace: litellm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/components-apps/litellm/litellm-app.yaml
+++ b/components-apps/litellm/litellm-app.yaml
@@ -12,7 +12,7 @@ spec:
   source:
     chart: app-template
     repoURL: https://bjw-s-labs.github.io/helm-charts
-    targetRevision: 4.6.2
+    targetRevision: 5.0.1
     helm:
       values: |-
 

--- a/components-apps/paperless/anyuid-rolebdining.yaml
+++ b/components-apps/paperless/anyuid-rolebdining.yaml
@@ -6,7 +6,10 @@ metadata:
     argocd.argoproj.io/sync-wave: "30"
 subjects:
   - kind: ServiceAccount
-    name: default
+    name: paperless-ng
+    namespace: paperless
+  - kind: ServiceAccount
+    name: paperless-gpt
     namespace: paperless
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/components-apps/paperless/paperless-ai-chart-app.yaml
+++ b/components-apps/paperless/paperless-ai-chart-app.yaml
@@ -12,7 +12,7 @@ spec:
   source:
     chart: app-template
     repoURL: https://bjw-s-labs.github.io/helm-charts
-    targetRevision: 4.6.2
+    targetRevision: 5.0.1
     helm:
       values: |-
 

--- a/components-apps/paperless/paperless-chart-app.yaml
+++ b/components-apps/paperless/paperless-chart-app.yaml
@@ -12,7 +12,7 @@ spec:
   source:
     chart: app-template
     repoURL: https://bjw-s-labs.github.io/helm-charts
-    targetRevision: 4.6.2
+    targetRevision: 5.0.1
     helm:
       values: |-
 

--- a/components-apps/resilio-sync/anyuid-rolebinding.yaml
+++ b/components-apps/resilio-sync/anyuid-rolebinding.yaml
@@ -4,7 +4,7 @@ metadata:
   name: resilio-sync-anyuid
 subjects:
   - kind: ServiceAccount
-    name: default
+    name: resilio-sync-app
     namespace: resilio-sync
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/components-apps/resilio-sync/privileged-rolebinding.yaml
+++ b/components-apps/resilio-sync/privileged-rolebinding.yaml
@@ -4,7 +4,7 @@ metadata:
   name: resilio-sync-privileged
 subjects:
   - kind: ServiceAccount
-    name: default
+    name: resilio-sync-app
     namespace: resilio-sync
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/components-apps/resilio-sync/resilio-sync-app.yaml
+++ b/components-apps/resilio-sync/resilio-sync-app.yaml
@@ -12,7 +12,7 @@ spec:
   source:
     chart: app-template
     repoURL: https://bjw-s-labs.github.io/helm-charts
-    targetRevision: 4.6.2
+    targetRevision: 5.0.1
     helm:
       values: |-
 

--- a/components-apps/taxbuddy-hermes/anyuid-rolebinding.yaml
+++ b/components-apps/taxbuddy-hermes/anyuid-rolebinding.yaml
@@ -6,7 +6,7 @@ metadata:
     argocd.argoproj.io/sync-wave: "30"
 subjects:
   - kind: ServiceAccount
-    name: default
+    name: taxbuddy-hermes-app
     namespace: taxbuddy-hermes
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/components-apps/taxbuddy-hermes/taxbuddy-hermes-app.yaml
+++ b/components-apps/taxbuddy-hermes/taxbuddy-hermes-app.yaml
@@ -12,7 +12,7 @@ spec:
   source:
     chart: app-template
     repoURL: https://bjw-s-labs.github.io/helm-charts
-    targetRevision: 4.6.2
+    targetRevision: 5.0.1
     helm:
       values: |-
         controllers:

--- a/components-apps/taxbuddy/anyuid-rolebinding.yaml
+++ b/components-apps/taxbuddy/anyuid-rolebinding.yaml
@@ -6,7 +6,7 @@ metadata:
     argocd.argoproj.io/sync-wave: "30"
 subjects:
   - kind: ServiceAccount
-    name: default
+    name: taxbuddy-app
     namespace: taxbuddy
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/components-apps/taxbuddy/taxbuddy-app.yaml
+++ b/components-apps/taxbuddy/taxbuddy-app.yaml
@@ -12,7 +12,7 @@ spec:
   source:
     chart: app-template
     repoURL: https://bjw-s-labs.github.io/helm-charts
-    targetRevision: 4.6.2
+    targetRevision: 5.0.1
     helm:
       values: |-
         defaultPodOptions:

--- a/components-apps/vaultwarden/vaultwarden.yaml
+++ b/components-apps/vaultwarden/vaultwarden.yaml
@@ -12,7 +12,7 @@ spec:
   source:
     chart: app-template
     repoURL: https://bjw-s-labs.github.io/helm-charts
-    targetRevision: 4.6.2
+    targetRevision: 5.0.1
     helm:
       values: |-
 

--- a/components-infra/restic-rest-server/overlays/sakaar/restic-rest-server.yaml
+++ b/components-infra/restic-rest-server/overlays/sakaar/restic-rest-server.yaml
@@ -12,7 +12,7 @@ spec:
   source:
     chart: app-template
     repoURL: https://bjw-s-labs.github.io/helm-charts
-    targetRevision: 4.6.2
+    targetRevision: 5.0.1
     helm:
       values: |-
 

--- a/components-infra/restic-rest-server/restic-rest-server.yaml
+++ b/components-infra/restic-rest-server/restic-rest-server.yaml
@@ -12,7 +12,7 @@ spec:
   source:
     chart: app-template
     repoURL: https://bjw-s-labs.github.io/helm-charts
-    targetRevision: 4.6.2
+    targetRevision: 5.0.1
     helm:
       values: |-
 


### PR DESCRIPTION
## Summary
- Bumps all remaining app-template Helm chart references from v4.6.2 to v5.0.1
- Updates SCC ClusterRoleBindings to target the chart-generated ServiceAccount (release name) instead of `default`
- Prevents the same crash we hit on `honcho-app` (#269) and `immich-app` (#268) from happening to every other app when the chart version eventually bumps

## Changes by app

| App | Chart bump | SCC binding update |
|-----|-----------|-------------------|
| litellm | 4.6.2 → 5.0.1 | anyuid: `default` → `litellm-app` |
| paperless | 4.6.2 → 5.0.1 (x2 charts) | anyuid: `default` → `paperless-ng` + `paperless-gpt` |
| resilio-sync | 4.6.2 → 5.0.1 | anyuid + privileged: `default` → `resilio-sync-app` |
| taxbuddy | 4.6.2 → 5.0.1 | anyuid: `default` → `taxbuddy-app` |
| taxbuddy-hermes | 4.6.2 → 5.0.1 | anyuid: `default` → `taxbuddy-hermes-app` |
| vaultwarden | 4.6.2 → 5.0.1 | No SCC needed (no `runAsUser: 0`) |
| restic-rest-server | 4.6.2 → 5.0.1 (base + sakaar) | No SCC needed (no `runAsUser: 0`) |

## Context
app-template v5.0.1 creates a dedicated ServiceAccount per Helm release instead of using `default`. Without updating the SCC bindings, pods fail with `Forbidden: not usable by user or serviceaccount` on OpenShift — exactly what happened to immich and honcho earlier today.

## Test plan
- [x] `kustomize build` passes for all 7 components
- [ ] After merge: all apps remain `Synced`/`Healthy` in ArgoCD on Altus
- [ ] Pods start successfully with new chart-created ServiceAccounts

🤖 Generated with [Claude Code](https://claude.com/claude-code)