### PR TITLE
feat(devland-editor-agent): wire HOME_OPS_READ_TOKEN for deploy-status checks

### DIFF
--- a/components-apps/litellm/anyuid-rolebinding.yaml
+++ b/components-apps/litellm/anyuid-rolebinding.yaml
@@ -6,7 +6,7 @@ metadata:
     argocd.argoproj.io/sync-wave: "30"
 subjects:
   - kind: ServiceAccount
-    name: default
+    name: litellm-app
     namespace: litellm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/components-apps/litellm/litellm-app.yaml
+++ b/components-apps/litellm/litellm-app.yaml
@@ -12,7 +12,7 @@ spec:
   source:
     chart: app-template
     repoURL: https://bjw-s-labs.github.io/helm-charts
-    targetRevision: 4.6.2
+    targetRevision: 5.0.1
     helm:
       values: |-
 

--- a/components-apps/paperless/anyuid-rolebdining.yaml
+++ b/components-apps/paperless/anyuid-rolebdining.yaml
@@ -6,7 +6,10 @@ metadata:
     argocd.argoproj.io/sync-wave: "30"
 subjects:
   - kind: ServiceAccount
-    name: default
+    name: paperless-ng
+    namespace: paperless
+  - kind: ServiceAccount
+    name: paperless-gpt
     namespace: paperless
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/components-apps/paperless/paperless-ai-chart-app.yaml
+++ b/components-apps/paperless/paperless-ai-chart-app.yaml
@@ -12,7 +12,7 @@ spec:
   source:
     chart: app-template
     repoURL: https://bjw-s-labs.github.io/helm-charts
-    targetRevision: 4.6.2
+    targetRevision: 5.0.1
     helm:
       values: |-
 

--- a/components-apps/paperless/paperless-chart-app.yaml
+++ b/components-apps/paperless/paperless-chart-app.yaml
@@ -12,7 +12,7 @@ spec:
   source:
     chart: app-template
     repoURL: https://bjw-s-labs.github.io/helm-charts
-    targetRevision: 4.6.2
+    targetRevision: 5.0.1
     helm:
       values: |-
 

--- a/components-apps/resilio-sync/anyuid-rolebinding.yaml
+++ b/components-apps/resilio-sync/anyuid-rolebinding.yaml
@@ -4,7 +4,7 @@ metadata:
   name: resilio-sync-anyuid
 subjects:
   - kind: ServiceAccount
-    name: default
+    name: resilio-sync-app
     namespace: resilio-sync
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/components-apps/resilio-sync/privileged-rolebinding.yaml
+++ b/components-apps/resilio-sync/privileged-rolebinding.yaml
@@ -4,7 +4,7 @@ metadata:
   name: resilio-sync-privileged
 subjects:
   - kind: ServiceAccount
-    name: default
+    name: resilio-sync-app
     namespace: resilio-sync
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/components-apps/resilio-sync/resilio-sync-app.yaml
+++ b/components-apps/resilio-sync/resilio-sync-app.yaml
@@ -12,7 +12,7 @@ spec:
   source:
     chart: app-template
     repoURL: https://bjw-s-labs.github.io/helm-charts
-    targetRevision: 4.6.2
+    targetRevision: 5.0.1
     helm:
       values: |-
 

--- a/components-apps/taxbuddy-hermes/anyuid-rolebinding.yaml
+++ b/components-apps/taxbuddy-hermes/anyuid-rolebinding.yaml
@@ -6,7 +6,7 @@ metadata:
     argocd.argoproj.io/sync-wave: "30"
 subjects:
   - kind: ServiceAccount
-    name: default
+    name: taxbuddy-hermes-app
     namespace: taxbuddy-hermes
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/components-apps/taxbuddy-hermes/taxbuddy-hermes-app.yaml
+++ b/components-apps/taxbuddy-hermes/taxbuddy-hermes-app.yaml
@@ -12,7 +12,7 @@ spec:
   source:
     chart: app-template
     repoURL: https://bjw-s-labs.github.io/helm-charts
-    targetRevision: 4.6.2
+    targetRevision: 5.0.1
     helm:
       values: |-
         controllers:

--- a/components-apps/taxbuddy/anyuid-rolebinding.yaml
+++ b/components-apps/taxbuddy/anyuid-rolebinding.yaml
@@ -6,7 +6,7 @@ metadata:
     argocd.argoproj.io/sync-wave: "30"
 subjects:
   - kind: ServiceAccount
-    name: default
+    name: taxbuddy-app
     namespace: taxbuddy
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/components-apps/taxbuddy/taxbuddy-app.yaml
+++ b/components-apps/taxbuddy/taxbuddy-app.yaml
@@ -12,7 +12,7 @@ spec:
   source:
     chart: app-template
     repoURL: https://bjw-s-labs.github.io/helm-charts
-    targetRevision: 4.6.2
+    targetRevision: 5.0.1
     helm:
       values: |-
         defaultPodOptions:

--- a/components-apps/vaultwarden/vaultwarden.yaml
+++ b/components-apps/vaultwarden/vaultwarden.yaml
@@ -12,7 +12,7 @@ spec:
   source:
     chart: app-template
     repoURL: https://bjw-s-labs.github.io/helm-charts
-    targetRevision: 4.6.2
+    targetRevision: 5.0.1
     helm:
       values: |-
 

--- a/components-infra/restic-rest-server/overlays/sakaar/restic-rest-server.yaml
+++ b/components-infra/restic-rest-server/overlays/sakaar/restic-rest-server.yaml
@@ -12,7 +12,7 @@ spec:
   source:
     chart: app-template
     repoURL: https://bjw-s-labs.github.io/helm-charts
-    targetRevision: 4.6.2
+    targetRevision: 5.0.1
     helm:
       values: |-
 

--- a/components-infra/restic-rest-server/restic-rest-server.yaml
+++ b/components-infra/restic-rest-server/restic-rest-server.yaml
@@ -12,7 +12,7 @@ spec:
   source:
     chart: app-template
     repoURL: https://bjw-s-labs.github.io/helm-charts
-    targetRevision: 4.6.2
+    targetRevision: 5.0.1
     helm:
       values: |-
 


### PR DESCRIPTION
Lets the running agent read home-ops's devland-bump-* PR state via a read-only token, distinct from GITHUB_TOKEN (which only covers devland-dummy) and from the write-scoped HOME_OPS_PAT CI uses. `optional: true` is set on the new secretKeyRef so the pod isn't stuck pending the Doppler secret (see docs/superpowers/plans/2026-08-06-auto-deploy-and-watch.md, Task 6, for provisioning it).