### PR TITLE
chore(devland-editor-agent): bump image to sha-78717c0

### DIFF
--- a/components-apps/devland-editor-agent/base/kustomization.yaml
+++ b/components-apps/devland-editor-agent/base/kustomization.yaml
@@ -16,4 +16,4 @@ resources:
 images:
   - name: ghcr.io/pixeljonas/devland-editor-agent
     newName: ghcr.io/pixeljonas/devland-editor-agent
-    digest: sha256:4caabfa92ec47612d74392888092460268bc8000e2e57a9f82ae7e62f1d6d2dd
+    digest: sha256:f9d03aef133910ad9a30dab9c550d09823fca65c3fef297c6dc664ff3e47cc16


### PR DESCRIPTION
Automated digest bump from devland-editor-agent CI.

Digest: sha256:f9d03aef133910ad9a30dab9c550d09823fca65c3fef297c6dc664ff3e47cc16
Source: https://github.com/PixelJonas/devland-editor-agent/commit/78717c08ec635758d13234707bea88d88b0481ad