### PR TITLE
feat(hermes-infra-agent): add read-only OpenShift RBAC for Hermes infra agent

### DIFF
--- a/bootstrap/overlays/local.home/values-infra.yaml
+++ b/bootstrap/overlays/local.home/values-infra.yaml
@@ -122,6 +122,12 @@ applications:
     source:
       path: components-infra/claude-admin/base
 
+  hermes-infra-agent:
+    annotations:
+      argocd.argoproj.io/sync-wave: "11"
+    source:
+      path: components-infra/hermes-infra-agent/base
+
   cloudflared:
     annotations:
       argocd.argoproj.io/sync-wave: "22"

--- a/bootstrap/overlays/sakaar/values-infra.yaml
+++ b/bootstrap/overlays/sakaar/values-infra.yaml
@@ -60,6 +60,12 @@ applications:
     source:
       path: components-infra/claude-admin/base
 
+  hermes-infra-agent:
+    annotations:
+      argocd.argoproj.io/sync-wave: "11"
+    source:
+      path: components-infra/hermes-infra-agent/base
+
   rbac:
     annotations:
       argocd.argoproj.io/compare-options: IgnoreExtraneous

--- a/components-infra/hermes-infra-agent/base/clusterrole.yaml
+++ b/components-infra/hermes-infra-agent/base/clusterrole.yaml
@@ -1,0 +1,36 @@
+# Hand-authored, deliberately narrow read-only ClusterRole for the Hermes
+# infra-ops investigate-only agent. No precedent existed in this repo for a
+# bespoke read-only ClusterRole (see components-infra/openshift-monitoring's
+# monitoring-role-binding.yaml for the closest analog, which binds to the
+# built-in cluster-monitoring-view ClusterRole instead of a hand-authored
+# one). Explicitly excludes pods/exec, secrets (any verb), and every write
+# verb (create/update/patch/delete) on anything -- this ClusterRole is the
+# entire security boundary for the credential, not just a convention the
+# agent is expected to follow.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: hermes-infra-read
+rules:
+  - apiGroups: [""]
+    resources:
+      - pods
+      - services
+      - events
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources:
+      - pods/log
+    verbs: ["get", "list"]
+  - apiGroups: ["apps"]
+    resources:
+      - deployments
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["route.openshift.io"]
+    resources:
+      - routes
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["argoproj.io"]
+    resources:
+      - applications
+    verbs: ["get", "list", "watch"]

--- a/components-infra/hermes-infra-agent/base/clusterrolebinding.yaml
+++ b/components-infra/hermes-infra-agent/base/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: hermes-infra-agent-read-binding
+subjects:
+  - kind: ServiceAccount
+    name: hermes-infra-agent
+    namespace: hermes-infra
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: hermes-infra-read

--- a/components-infra/hermes-infra-agent/base/kustomization.yaml
+++ b/components-infra/hermes-infra-agent/base/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - namespace.yaml
+  - serviceaccount.yaml
+  - clusterrole.yaml
+  - clusterrolebinding.yaml
+  - secret.yaml

--- a/components-infra/hermes-infra-agent/base/namespace.yaml
+++ b/components-infra/hermes-infra-agent/base/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: hermes-infra

--- a/components-infra/hermes-infra-agent/base/secret.yaml
+++ b/components-infra/hermes-infra-agent/base/secret.yaml
@@ -1,0 +1,15 @@
+# Legacy-style long-lived service-account token (no TokenRequest expiry,
+# unlike `oc create token`). The annotation is what triggers the
+# controller to auto-populate `data.token`/`data.ca.crt` at runtime — this
+# manifest itself carries no secret value. Same pattern as
+# components-infra/claude-admin/base/secret.yaml, but unlike claude-admin
+# this token IS synced out to Doppler (HERMES_SAKAAR_KUBECONFIG /
+# HERMES_ALTUS_KUBECONFIG) rather than left as a manual `oc get secret` step.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hermes-infra-agent-token
+  namespace: hermes-infra
+  annotations:
+    kubernetes.io/service-account.name: hermes-infra-agent
+type: kubernetes.io/service-account-token

--- a/components-infra/hermes-infra-agent/base/serviceaccount.yaml
+++ b/components-infra/hermes-infra-agent/base/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: hermes-infra-agent
+  namespace: hermes-infra


### PR DESCRIPTION
## Summary
- Component 4 of the Hermes infra-ops agent plan: new `components-infra/hermes-infra-agent/base` component (namespace, ServiceAccount, hand-authored read-only ClusterRole `hermes-infra-read`, ClusterRoleBinding, long-lived token Secret)
- ClusterRole grants only get/list/watch on pods, deployments, events, services, `routes.route.openshift.io`, and `applications.argoproj.io`, plus get/list on `pods/log` — explicitly no `pods/exec`, no `secrets` access, no write verbs anywhere
- Registered in both `bootstrap/overlays/sakaar/values-infra.yaml` and `bootstrap/overlays/local.home/values-infra.yaml` (components-infra/ is a shared tree consumed by both clusters' app-of-apps)

## Test plan
- [x] `kustomize build components-infra/hermes-infra-agent/base` renders cleanly
- [x] `kustomize build bootstrap/overlays/sakaar --enable-helm` renders the `hermes-infra-agent` Application
- [x] `kustomize build bootstrap/overlays/local.home --enable-helm` renders the `hermes-infra-agent` Application
- [ ] ArgoCD syncs `hermes-infra-agent` to `Synced`/`Healthy` on both Sakaar and Altus after merge
- [ ] `oc auth can-i get pods -A` → yes, `delete`/`create pods -A` → no, using the resulting ServiceAccount token, on both clusters

Assisted-by: Claude Code