### PR TITLE
feat(devland-editor-agent): wire HOME_OPS_READ_TOKEN for deploy-status checks

### DIFF
--- a/components-apps/devland-editor-agent/base/deployment.yaml
+++ b/components-apps/devland-editor-agent/base/deployment.yaml
@@ -103,6 +103,7 @@ spec:
                 secretKeyRef:
                   name: devland-editor-agent-secrets
                   key: home_ops_read_token
+                  optional: true
             - name: NTFY_URL
               valueFrom:
                 secretKeyRef:

--- a/components-apps/devland-editor-agent/base/deployment.yaml
+++ b/components-apps/devland-editor-agent/base/deployment.yaml
@@ -98,6 +98,11 @@ spec:
                 secretKeyRef:
                   name: devland-editor-agent-secrets
                   key: github_token
+            - name: HOME_OPS_READ_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: devland-editor-agent-secrets
+                  key: home_ops_read_token
             - name: NTFY_URL
               valueFrom:
                 secretKeyRef:

--- a/components-apps/devland-editor-agent/base/externalsecret.yaml
+++ b/components-apps/devland-editor-agent/base/externalsecret.yaml
@@ -20,6 +20,9 @@ spec:
     - secretKey: github_token
       remoteRef:
         key: DEVLAND_EDITOR_AGENT_GITHUB_TOKEN
+    - secretKey: home_ops_read_token
+      remoteRef:
+        key: DEVLAND_EDITOR_AGENT_HOME_OPS_READ_TOKEN
     - secretKey: ntfy_url
       remoteRef:
         key: DEVLAND_EDITOR_AGENT_NTFY_URL


### PR DESCRIPTION
Redo of #271, which accidentally got created off fix/app-template-5.0.1-scc-migration instead of main and ended up merging that branch's SCC content instead of this change. This PR is correctly based on current main (which already includes #270's content) and carries only the two actual commits: the HOME_OPS_READ_TOKEN wiring and the optional:true fix.