### PR TITLE
fix(taxbuddy): mount agent-runtime's SA token so hermes cron-exec can authenticate

### DIFF
--- a/components-apps/taxbuddy/taxbuddy-app.yaml
+++ b/components-apps/taxbuddy/taxbuddy-app.yaml
@@ -168,6 +168,16 @@ spec:
 
           agent-runtime:
             replicas: 1
+            pod:
+              # app-template's chart default is false. This controller's
+              # startup lifespan calls `oc exec deploy/taxbuddy-hermes-app`
+              # (via agent_hermes/adapter.py, to register its cron trigger)
+              # using the pod's own in-cluster token -- with no token
+              # mounted at all, that call fails at authentication before
+              # RBAC is even evaluated, crash-looping the pod on every
+              # restart. See taxbuddy/agent-runtime-hermes-exec-rbac.yaml
+              # for the matching RBAC grant this token needs.
+              automountServiceAccountToken: true
             containers:
               agent-runtime:
                 image:


### PR DESCRIPTION
Fixes taxbuddy-app-agent-runtime's CrashLoopBackOff. Follow-up to #276 (which fixed the RoleBinding's SA name but wasn't sufficient alone).

Root cause: app-template's chart default is `automountServiceAccountToken: false`. This controller's startup lifespan calls `oc exec deploy/taxbuddy-hermes-app -- hermes cron create ...` using its own in-cluster token to register a cron trigger — with no token mounted at all, that call fails at authentication before RBAC is even evaluated.

Confirmed live: pod spec showed `automountServiceAccountToken: false` and zero mounted volumes; the identical `oc exec` command succeeded when manually run with `--as=system:serviceaccount:taxbuddy:taxbuddy-app`, proving #276's RBAC fix was correct and this was the actual remaining blocker.