### PR TITLE
feat(hermes-infra-agent): grant read-only nodes/jobs/cronjobs access

### DIFF
--- a/components-infra/hermes-infra-agent/base/clusterrole.yaml
+++ b/components-infra/hermes-infra-agent/base/clusterrole.yaml
@@ -7,6 +7,11 @@
 # verb (create/update/patch/delete) on anything -- this ClusterRole is the
 # entire security boundary for the credential, not just a convention the
 # agent is expected to follow.
+#
+# nodes/jobs/cronjobs added 2026-08-07: the agent's ssh_diagnose/k8s_get
+# MCP tools were live-verified working end-to-end, but a `k8s_get nodes`
+# call hit a real RBAC Forbidden (cluster-scoped nodes weren't covered) --
+# widened deliberately on request, still read-only (get/list/watch only).
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -17,6 +22,7 @@ rules:
       - pods
       - services
       - events
+      - nodes
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources:
@@ -25,6 +31,11 @@ rules:
   - apiGroups: ["apps"]
     resources:
       - deployments
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["batch"]
+    resources:
+      - jobs
+      - cronjobs
     verbs: ["get", "list", "watch"]
   - apiGroups: ["route.openshift.io"]
     resources:


### PR DESCRIPTION
## Summary
- Widens the `hermes-infra-read` ClusterRole (used by Heimdall, the homelab infra-ops Hermes agent) to also cover `nodes` (core group) and `jobs`/`cronjobs` (batch group)
- Still strictly `get`/`list`/`watch` — no new write verbs, no `pods/exec`, no secrets access
- Applies to both Sakaar and Altus (shared `components-infra/` tree)

## Why
Heimdall's `k8s_get` MCP tool was live-verified working end-to-end for pods/deployments/ArgoCD Applications/routes, but a `k8s_get nodes` call hit a real RBAC `Forbidden` — cluster-scoped `nodes` wasn't covered by the original v1 ClusterRole. Requested follow-up to close that gap, plus `jobs`/`cronjobs` for CronJob-failure investigation (a common homelab GitOps failure mode already documented in `homelab-gitops-investigation`, this agent's own skill).

## Test plan
- [x] `kustomize build components-infra/hermes-infra-agent/base` renders cleanly with the new rules
- [ ] After merge + ArgoCD sync, re-verify live: `k8s_get nodes`/`k8s_get jobs`/`k8s_get cronjobs` on both sakaar and altus should now succeed instead of Forbidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)