### PR TITLE
fix(nextcloud): wire MariaDB credentials into chart's DB env vars

### DIFF
--- a/components-apps/nextcloud/external-nextcloud-mariadb.yaml
+++ b/components-apps/nextcloud/external-nextcloud-mariadb.yaml
@@ -18,3 +18,6 @@ spec:
     - secretKey: mariadb-password
       remoteRef:
         key: NEXTCLOUD_MARIADB_PASSWORD
+    - secretKey: mariadb-username
+      remoteRef:
+        key: NEXTCLOUD_MARIADB_USERNAME

--- a/components-apps/nextcloud/nextcloud-app.yaml
+++ b/components-apps/nextcloud/nextcloud-app.yaml
@@ -48,6 +48,23 @@ spec:
           enabled: true
           protocol: https
 
+        # The chart's own MYSQL_HOST/USER/PASSWORD env-var wiring (used by
+        # both the main container and the mariadb-isalive init container)
+        # is gated on internalDatabase.enabled, not mariadb.enabled -- it
+        # defaults to true (SQLite) and silently wins over the bundled
+        # MariaDB subchart unless explicitly disabled here. externalDatabase
+        # .existingSecret is still the correct place for credentials even
+        # though we're using the bundled subchart, not a real external DB --
+        # that's simply where this chart's template always reads them from.
+        internalDatabase:
+          enabled: false
+
+        externalDatabase:
+          existingSecret:
+            secretName: nextcloud-mariadb
+            usernameKey: mariadb-username
+            passwordKey: mariadb-password
+
         persistence:
           enabled: true
           storageClass: synology-iscsi-storage


### PR DESCRIPTION
## Summary
Found during Task 3 live verification of PR #279: the Nextcloud pod's `mariadb-isalive` init container was stuck indefinitely because the chart's `internalDatabase.enabled` flag (defaults `true`, SQLite) silently overrides `mariadb.enabled` in the chart's env-var templating. Fixes by explicitly disabling it and pointing `externalDatabase.existingSecret` at the same Doppler-backed secret already used for MariaDB's own auth, plus adding the missing username key.

## Test plan
- [x] `helm template` against the pinned chart version (9.2.5) with these exact values confirms MYSQL_HOST/USER/PASSWORD now resolve correctly
- [ ] Post-merge: mariadb-isalive init container completes, Nextcloud pod reaches Ready

🤖 Generated with [Claude Code](https://claude.com/claude-code)