### PR TITLE
fix(nextcloud): pin redis replica PVCs to synology-iscsi-storage

### DIFF
--- a/components-apps/nextcloud/nextcloud-app.yaml
+++ b/components-apps/nextcloud/nextcloud-app.yaml
@@ -98,6 +98,11 @@ spec:
               enabled: true
               storageClass: synology-iscsi-storage
               size: 2Gi
+          replica:
+            persistence:
+              enabled: true
+              storageClass: synology-iscsi-storage
+              size: 2Gi
           global:
             compatibility:
               openshift:


### PR DESCRIPTION
## Summary
Found during Task 3 live verification: the 3 Redis replica PVCs landed on `lvms-vg1` (cluster default) instead of `synology-iscsi-storage`, because only `redis.master.persistence.storageClass` was set, not `redis.replica.persistence.storageClass`. Low severity (disposable cache data), but violates the project's explicit storage-class constraint.

## Test plan
- [x] Confirmed `replica.persistence.storageClass` is the correct Bitnami redis chart key
- [ ] Post-merge: delete the 3 misplaced PVCs (StatefulSet volumeClaimTemplate changes don't retroactively migrate existing PVCs) and let them recreate on the correct StorageClass

🤖 Generated with [Claude Code](https://claude.com/claude-code)