### PR TITLE
feat(nextcloud): monitoring via chart-native exporter + ServiceMonitor + alerts

### DIFF
--- a/components-apps/nextcloud/external-nextcloud-admin.yaml
+++ b/components-apps/nextcloud/external-nextcloud-admin.yaml
@@ -18,3 +18,6 @@ spec:
     - secretKey: nextcloud-password
       remoteRef:
         key: NEXTCLOUD_ADMIN_PASSWORD
+    - secretKey: nextcloud-token
+      remoteRef:
+        key: NEXTCLOUD_EXPORTER_TOKEN

--- a/components-apps/nextcloud/kustomization.yaml
+++ b/components-apps/nextcloud/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - external-nextcloud-redis.yaml
   - nextcloud-app.yaml
   - servicemonitor.yaml
+  - prometheus-rule.yaml

--- a/components-apps/nextcloud/kustomization.yaml
+++ b/components-apps/nextcloud/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - external-nextcloud-mariadb.yaml
   - external-nextcloud-redis.yaml
   - nextcloud-app.yaml
+  - servicemonitor.yaml

--- a/components-apps/nextcloud/nextcloud-app.yaml
+++ b/components-apps/nextcloud/nextcloud-app.yaml
@@ -132,7 +132,8 @@ spec:
         metrics:
           enabled: true
           image:
-            tag: 0.9.1 # renovate: datasource=docker depName=xperimental/nextcloud-exporter
+            repository: xperimental/nextcloud-exporter
+            tag: 0.9.1
           info:
             # nextcloud_system_update_available metric (dashboard panel 7)
             update: true

--- a/components-apps/nextcloud/nextcloud-app.yaml
+++ b/components-apps/nextcloud/nextcloud-app.yaml
@@ -22,6 +22,12 @@ spec:
             secretName: nextcloud-admin
             usernameKey: nextcloud-username
             passwordKey: nextcloud-password
+            # nextcloud-exporter auth token (Task 2/3 of the monitoring plan)
+            # -- read by the chart's own templates/metrics/deployment.yaml
+            # as NEXTCLOUD_AUTH_TOKEN, out of this SAME existingSecret since
+            # the template only supports one secret name for the whole
+            # nextcloud.existingSecret block, not a per-key override.
+            tokenKey: nextcloud-token
           trustedDomains:
             - nextcloud.apps.altus.janz.digital
             - nextcloud.janz.digital
@@ -115,6 +121,21 @@ spec:
             route.openshift.io/termination: "edge"
           path: /
           pathType: Prefix
+
+        # nextcloud-exporter, deployed via the chart's own dedicated
+        # metrics.* mechanism (a purpose-built Deployment + Service for
+        # xperimental/nextcloud-exporter, not a generic sidecar) --
+        # preferred over hand-rolling extraSidecarContainers because it
+        # already wires NEXTCLOUD_SERVER, the /ocs/.../serverinfo path, and
+        # NEXTCLOUD_AUTH_TOKEN (via nextcloud.existingSecret.tokenKey above)
+        # correctly out of the box. See monitoring-report.md for details.
+        metrics:
+          enabled: true
+          image:
+            tag: 0.9.1 # renovate: datasource=docker depName=xperimental/nextcloud-exporter
+          info:
+            # nextcloud_system_update_available metric (dashboard panel 7)
+            update: true
 
   project: cluster-apps
   syncPolicy:

--- a/components-apps/nextcloud/prometheus-rule.yaml
+++ b/components-apps/nextcloud/prometheus-rule.yaml
@@ -1,0 +1,48 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: nextcloud-alerts
+  namespace: nextcloud
+  labels:
+    app.kubernetes.io/name: nextcloud
+spec:
+  groups:
+    - name: Nextcloud
+      rules:
+        - alert: NextcloudServiceDown
+          expr: nextcloud_up == 0
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Nextcloud is unreachable"
+            description: "nextcloud-exporter has reported nextcloud_up == 0 for 5 minutes."
+
+        - alert: NextcloudBackupMissedInterval
+          expr: increase(volsync_missed_intervals_total{obj_namespace="nextcloud"}[1d]) > 0
+          for: 0m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Nextcloud VolSync backup missed its scheduled window"
+            description: "{{ $labels.obj_name }} in namespace nextcloud did not complete a backup sync before its next scheduled trigger."
+
+        - alert: NextcloudBackupOutOfSync
+          expr: volsync_volume_out_of_sync{obj_namespace="nextcloud"} == 1
+          for: 30m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Nextcloud VolSync volume is out of sync"
+            description: "{{ $labels.obj_name }} has been out of sync for over 30 minutes."
+
+        - alert: NextcloudPVCUsageHigh
+          expr: |
+            kubelet_volume_stats_used_bytes{namespace="nextcloud"}
+              / kubelet_volume_stats_capacity_bytes{namespace="nextcloud"} > 0.85
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Nextcloud PVC {{ $labels.persistentvolumeclaim }} is over 85% full"
+            description: "{{ $labels.persistentvolumeclaim }} in namespace nextcloud is at {{ $value | humanizePercentage }} usage."

--- a/components-apps/nextcloud/servicemonitor.yaml
+++ b/components-apps/nextcloud/servicemonitor.yaml
@@ -1,0 +1,21 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: nextcloud-exporter
+  namespace: nextcloud
+  labels:
+    app.kubernetes.io/name: nextcloud
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: nextcloud
+      app.kubernetes.io/instance: nextcloud-app
+      app.kubernetes.io/component: metrics
+  namespaceSelector:
+    matchNames:
+      - nextcloud
+  endpoints:
+    - port: http
+      path: /metrics
+      interval: 60s
+      scrapeTimeout: 30s


### PR DESCRIPTION
## Summary
- Enables the `nextcloud/helm` chart's native `metrics.*` block (xperimental/nextcloud-exporter, wired correctly out of the box) rather than a hand-rolled sidecar.
- ServiceMonitor targeting the chart's own `nextcloud-app-metrics` Service.
- PrometheusRule: service-down, VolSync backup-missed/out-of-sync, PVC-usage alerts, wired into Altus's existing in-cluster Prometheus/Alertmanager (confirmed authoritative — no remote-write elsewhere).

## Test plan
- [x] Independent review: chart-feature claims verified against real upstream chart source (not invented), ServiceMonitor selector confirmed to target the correct Service, PromQL expressions reference real metrics
- [x] Fixed post-review: Renovate tracking comment didn't match this repo's actual regex config, corrected
- [ ] Post-merge, follow-up (tracked separately): create the exporter's `occ` user + `NEXTCLOUD_EXPORTER_TOKEN` Doppler secret (deliberately not done by the implementer — live credential-creating mutation)
- [ ] Post-merge: live alert-firing verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)