### PR TITLE
fix(nextcloud): move MariaDB/app-data/Redis to lvms-vg1

### DIFF
--- a/components-apps/nextcloud/nextcloud-app.yaml
+++ b/components-apps/nextcloud/nextcloud-app.yaml
@@ -73,7 +73,7 @@ spec:
 
         persistence:
           enabled: true
-          storageClass: synology-iscsi-storage
+          storageClass: lvms-vg1
           accessMode: ReadWriteOnce
           size: 20Gi
 
@@ -86,7 +86,7 @@ spec:
           primary:
             persistence:
               enabled: true
-              storageClass: synology-iscsi-storage
+              storageClass: lvms-vg1
               size: 10Gi
           global:
             compatibility:
@@ -102,12 +102,12 @@ spec:
           master:
             persistence:
               enabled: true
-              storageClass: synology-iscsi-storage
+              storageClass: lvms-vg1
               size: 2Gi
           replica:
             persistence:
               enabled: true
-              storageClass: synology-iscsi-storage
+              storageClass: lvms-vg1
               size: 2Gi
           global:
             compatibility:


### PR DESCRIPTION
## Summary
Reassessed the original synology-iscsi-storage choice after being challenged on it: every other stateful app on this cluster (paperless, vaultwarden, immich, litellm, taxbuddy, honcho, jellystat, even OpenShift's own Prometheus/Alertmanager) runs on `lvms-vg1` (local NVMe/SSD via TopoLVM), with durability from VolSync+B2 backups rather than the storage medium. Moving Nextcloud's MariaDB, app-data, and Redis PVCs there too, for consistency and better DB transaction latency.

## Migration plan (performed manually post-merge, not via this diff)
- Full `mariadb-dump` backup taken before touching anything
- App-data directory (187MB) tar'd and backed up locally
- After sync: delete old StatefulSet/PVCs (storageClassName + volumeClaimTemplates are immutable), let fresh ones provision on lvms-vg1, restore both backups

## Test plan
- [x] `kustomize build` renders cleanly
- [x] Pre-migration backups taken (SQL dump + data tarball)
- [ ] Post-merge: live migration + data restore + verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)