### PR TITLE
fix(nextcloud): run background jobs via k8s CronJob, not AJAX

### DIFF
--- a/components-apps/nextcloud/nextcloud-app.yaml
+++ b/components-apps/nextcloud/nextcloud-app.yaml
@@ -71,6 +71,24 @@ spec:
             usernameKey: mariadb-username
             passwordKey: mariadb-password
 
+        # Background jobs hardening: chart default (cronjob.enabled: false)
+        # leaves Nextcloud on its weakest "ajax" trigger mode (background
+        # jobs only run opportunistically off page-load traffic, no crond
+        # sidecar or CronJob exists otherwise). Use a real Kubernetes
+        # CronJob instead of the sidecar type -- sidecar needs crond running
+        # as root in the main pod, cronjob type runs `php -f cron.php` as a
+        # separate Job on the existing schedule/volumes, consistent with
+        # how this chart's docs recommend doing it on Kubernetes. Nextcloud
+        # itself still needs `occ background:cron` run once (see hardening
+        # notes) to flip config.php's backgroundjobs_mode from the ajax
+        # default to cron -- this chart value alone only creates the
+        # CronJob, it doesn't flip that setting.
+        cronjob:
+          enabled: true
+          type: cronjob
+          cronjob:
+            schedule: "*/5 * * * *"
+
         persistence:
           enabled: true
           storageClass: lvms-vg1


### PR DESCRIPTION
## Summary
- Part of the internet-exposure hardening pass for the live public Nextcloud instance (`nextcloud.janz.digital`).
- Confirmed live that background jobs were running on Nextcloud's weakest "ajax" trigger: `cronjob.enabled` defaults to `false` in the `nextcloud/helm` chart and nothing in this app's values overrode it — no crond sidecar, no CronJob for Nextcloud itself (only the unrelated `database-mariadb-backup` CronJob), and no explicit `backgroundjobs_mode` in `config.php`.
- Adds `cronjob.enabled: true` / `cronjob.type: cronjob` (5-minute schedule) to run `php cron.php` as a proper Kubernetes CronJob on the existing volumes — the chart's own recommended non-root pattern (vs. the `sidecar` type, which needs crond running as root in the main pod).
- Verified via `helm template` against the live chart version (9.2.5) that this renders a correct `CronJob` object with the right image, env, and volume mounts.

## Follow-up (not in this PR)
Once this merges and ArgoCD syncs, the new `nextcloud-app-cron` CronJob needs to be confirmed running successfully at least once, and only then should `occ background:cron` be run once (out-of-band, live) to flip `config.php`'s `backgroundjobs_mode` from the `ajax` default to `cron`. Flipping that setting before the CronJob is confirmed working would stop background jobs entirely (worse than the current ajax mode), so it's deliberately being done as a separate, order-dependent step.

## Test plan
- [x] `helm template` locally against chart 9.2.5 with the updated values — confirmed `CronJob` renders correctly.
- [ ] After merge: `oc get cronjob -n nextcloud` shows `nextcloud-app-cron`.
- [ ] After merge: `oc get jobs -n nextcloud` / job pod logs show at least one successful `cron.php` run.
- [ ] Only then: run `occ background:cron` via `oc exec` and confirm `config.php`'s `backgroundjobs_mode` is `cron`.

Assisted-by: Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)