### PR TITLE
feat(nextcloud): split user-file storage to Synology NFS, add Fastmail SMTP

### DIFF
--- a/components-apps/nextcloud/external-nextcloud-admin.yaml
+++ b/components-apps/nextcloud/external-nextcloud-admin.yaml
@@ -21,3 +21,12 @@ spec:
     - secretKey: nextcloud-token
       remoteRef:
         key: NEXTCLOUD_EXPORTER_TOKEN
+    - secretKey: smtp-host
+      remoteRef:
+        key: MAIL_HOST
+    - secretKey: smtp-username
+      remoteRef:
+        key: MAIL_USERNAME
+    - secretKey: smtp-password
+      remoteRef:
+        key: MAIL_PASSWORD

--- a/components-apps/nextcloud/nextcloud-app.yaml
+++ b/components-apps/nextcloud/nextcloud-app.yaml
@@ -49,6 +49,19 @@ spec:
             fsGroup: 0
           securityContext:
             runAsUser: 0
+          ## SMTP via the household's existing Fastmail account, sending
+          ## as cloud@famjanz.de. host/name/password come from the same
+          ## nextcloud-admin existingSecret above (smtp-host/smtp-username/
+          ## smtp-password keys, ExternalSecret-synced from Doppler
+          ## MAIL_HOST/MAIL_USERNAME/MAIL_PASSWORD in homelab/home).
+          mail:
+            enabled: true
+            fromAddress: cloud
+            domain: famjanz.de
+            smtp:
+              secure: ssl
+              port: 465
+              authtype: LOGIN
 
         phpClientHttpsFix:
           enabled: true
@@ -94,6 +107,22 @@ spec:
           storageClass: lvms-vg1
           accessMode: ReadWriteOnce
           size: 20Gi
+          # User file storage (nextcloud.datadir, /var/www/html/data) split
+          # onto its own PVC backed by the Synology NAS via the existing
+          # nfs-subdir-external-provisioner setup (same synology-nfs-storage
+          # StorageClass already used by paperless/resilio-sync/restic-rest-
+          # server) -- webroot/config/custom_apps/themes above stay on
+          # lvms-vg1. Done ahead of real usage so the family's growing file
+          # storage lands on the NAS's much larger volume instead of local
+          # NVMe, without needing another live migration later. Size is
+          # nominal -- nfs-subdir-external-provisioner doesn't enforce PVC
+          # quota, the real ceiling is the shared Synology volume's free
+          # space.
+          nextcloudData:
+            enabled: true
+            storageClass: synology-nfs-storage
+            accessMode: ReadWriteOnce
+            size: 100Gi
 
         mariadb:
           enabled: true


### PR DESCRIPTION
## Summary
- Give `nextcloud.datadir` (`/var/www/html/data`) its own PVC on the existing `synology-nfs-storage` StorageClass (nfs-subdir-external-provisioner), done ahead of real family usage so growing file storage lands on the NAS's larger volume instead of local NVMe. Webroot/config/custom_apps/themes stay on `lvms-vg1`, untouched.
- Wire SMTP via the household's existing Fastmail account so Nextcloud can send notification email, sending as `cloud@famjanz.de`. Reuses the generic `MAIL_HOST`/`MAIL_USERNAME`/`MAIL_PASSWORD` secrets already in Doppler `homelab/home` — no new secrets needed.

## Test plan
- [ ] Merge, then force an ArgoCD sync on `nextcloud-app` (auto-sync currently paused for the live migration) and confirm the new `nextcloud-app-nextcloud-data` PVC binds on `synology-nfs-storage`
- [ ] Restore the pre-migration data backup into the new PVC, confirm `df -h /var/www/html/data` shows the NFS mount
- [ ] Confirm `occ config:list system` shows `mail_smtphost`/`mail_from_address`/`mail_domain` set correctly, then send a real test email from Nextcloud's admin settings
- [ ] Confirm `cloud@famjanz.de` is a valid send-as alias on the Fastmail account backing `MAIL_USERNAME`

🤖 Generated with [Claude Code](https://claude.com/claude-code)