### PR TITLE
fix(nextcloud): pin cronjob container to www-data UID, not root

### DIFF
--- a/components-apps/nextcloud/nextcloud-app.yaml
+++ b/components-apps/nextcloud/nextcloud-app.yaml
@@ -88,6 +88,18 @@ spec:
           type: cronjob
           cronjob:
             schedule: "*/5 * * * *"
+            # The chart's cronjob-type container does NOT inherit the
+            # Deployment's podSecurityContext/securityContext above (those
+            # are only wired to the main app pod template) -- confirmed
+            # live: first run failed with "Console has to be executed with
+            # the user that owns the file config/config.php. Current user
+            # id: 0, Owner id of config.php: 33" because this container
+            # otherwise defaults to root, same as the main pod. Pin it to
+            # www-data (33) explicitly, matching config.php's real on-disk
+            # owner, so cron.php's own UID check passes.
+            securityContext:
+              runAsUser: 33
+              runAsGroup: 33
 
         persistence:
           enabled: true


### PR DESCRIPTION
## Summary
- Follow-up to #290. After that PR merged and ArgoCD synced, the new `nextcloud-app-cron` CronJob's first run failed:
  ```
  Console has to be executed with the user that owns the file config/config.php.
  Current user id: 0
  Owner id of config.php: 33
  ```
- Root cause: the `nextcloud/helm` chart's `cronjob`-type container does not inherit `nextcloud.podSecurityContext`/`nextcloud.securityContext` (those are only wired into the main app Deployment's pod template, confirmed against the chart's `templates/cronjob.yaml`) — it defaults to root, same as the main pod's forced-root override, but `cron.php`'s own bootstrap explicitly refuses to run as a UID that doesn't own `config.php` (uid 33 / www-data on disk).
- Fix: pin `cronjob.cronjob.securityContext` to `runAsUser: 33` / `runAsGroup: 33`, matching config.php's real owner.

## Test plan
- [x] `helm template` locally against chart 9.2.5 confirms the `securityContext` renders correctly under the CronJob's container spec.
- [ ] After merge + ArgoCD sync: confirm the next scheduled `nextcloud-app-cron` run completes successfully (`oc get jobs -n nextcloud`).
- [ ] Only then: run `occ background:cron` via `oc exec` to flip `config.php`'s `backgroundjobs_mode` to `cron`.

Assisted-by: Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)