### PR TITLE
feat(nextcloud): add local backup for the NFS user-file-data PVC

### DIFF
--- a/components-apps/nextcloud/backup/data-nfs/kustomization.yaml
+++ b/components-apps/nextcloud/backup/data-nfs/kustomization.yaml
@@ -1,0 +1,23 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namePrefix: data-nfs-
+namespace: nextcloud
+
+resources:
+  - ../../../../templates/volsync/rest
+
+patches:
+  - target:
+      group: volsync.backube
+      version: v1alpha1
+      kind: ReplicationSource
+      name: backup
+    path: local.yaml
+
+  - target:
+      group: external-secrets.io
+      version: v1
+      kind: ExternalSecret
+      name: external-restic-config
+    path: local-secret.yaml

--- a/components-apps/nextcloud/backup/data-nfs/local-secret.yaml
+++ b/components-apps/nextcloud/backup/data-nfs/local-secret.yaml
@@ -1,0 +1,7 @@
+- op: replace
+  path: /spec/target/name
+  value: restic-config-data-nfs
+
+- op: replace
+  path: /spec/data/0/remoteRef/key
+  value: NEXTCLOUD_DATA_NFS_REST_REPO_LOCAL

--- a/components-apps/nextcloud/backup/data-nfs/local.yaml
+++ b/components-apps/nextcloud/backup/data-nfs/local.yaml
@@ -1,0 +1,16 @@
+- op: replace
+  path: /spec/sourcePVC
+  value: nextcloud-app-nextcloud-data
+
+- op: replace
+  path: /spec/restic/repository
+  value: restic-config-data-nfs
+
+# Local-only for now, per explicit instruction -- no B2 leg yet. Run
+# shortly after the webroot/database backup's coordinated 03:00-03:12
+# maintenance window (see docs/runbooks/nextcloud-restore.md) rather than
+# inside it, since this PVC isn't part of that DB-consistency guarantee --
+# just avoiding concurrent backup load against the same NFS export.
+- op: replace
+  path: /spec/trigger/schedule
+  value: "15 3 * * *"

--- a/components-apps/nextcloud/backup/kustomization.yaml
+++ b/components-apps/nextcloud/backup/kustomization.yaml
@@ -3,4 +3,5 @@ kind: Kustomization
 
 resources:
   - ./data
+  - ./data-nfs
   - ./database


### PR DESCRIPTION
## Summary
- Adds a local-only VolSync `ReplicationSource` for `nextcloud-app-nextcloud-data` (the `synology-nfs-storage` PVC added when user-file storage was split off from the original app-data PVC), mirroring the existing `data-backup` pattern. No B2 leg yet, per explicit instruction.
- Closes a real gap flagged in `docs/runbooks/nextcloud-restore.md` (PR #293): this PVC previously had zero backup coverage.
- Confirmed this lands in the same restic-rest-server storage path (`/volume1/configs/restic-rest-restic-rest-server-app`) that `stacks/synology/tailsafe` already backs up wholesale via its `cluster-backups` source mount — no tailsafe-side change needed for an off-site copy to also happen automatically.

## Test plan
- [ ] After merge + sync, confirm `ReplicationSource/data-nfs-backup` runs successfully at 03:15 and creates the `restic-config-data-nfs` repo
- [ ] Confirm the new repo appears under `/volume1/configs/restic-rest-restic-rest-server-app/nextcloud-data-nfs/` on the NAS and gets picked up by the next tailsafe backup cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)