### PR TITLE
fix(nextcloud): fix data-nfs-backup mover permissions (root_squash + SCC)

### DIFF
--- a/components-apps/nextcloud/anyuid-rolebinding.yaml
+++ b/components-apps/nextcloud/anyuid-rolebinding.yaml
@@ -8,6 +8,14 @@ subjects:
   - kind: ServiceAccount
     name: default
     namespace: nextcloud
+  # VolSync's data-nfs-backup mover needs to run as uid 33/www-data to
+  # read the synology-nfs-storage PVC (root_squash blocks the default
+  # OpenShift-assigned uid range from reading files owned by www-data --
+  # see .claude/rules/synology.md in infra-ops). VolSync auto-creates
+  # this ServiceAccount per-ReplicationSource, named after it.
+  - kind: ServiceAccount
+    name: volsync-src-data-nfs-backup
+    namespace: nextcloud
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/components-apps/nextcloud/backup/data-nfs/local.yaml
+++ b/components-apps/nextcloud/backup/data-nfs/local.yaml
@@ -6,6 +6,20 @@
   path: /spec/restic/repository
   value: restic-config-data-nfs
 
+# This PVC's underlying Synology NFS export uses root_squash -- the
+# default OpenShift-assigned mover uid can't read files owned by
+# www-data (33), the actual app's runtime uid. Run the mover as uid 33
+# too (see anyuid-rolebinding.yaml for the matching SCC grant this
+# needs -- VolSync's dynamically-created "volsync-src-data-nfs-backup"
+# ServiceAccount is bound to anyuid there). See .claude/rules/
+# synology.md in infra-ops for the full root_squash writeup.
+- op: add
+  path: /spec/restic/moverSecurityContext
+  value:
+    runAsUser: 33
+    runAsGroup: 33
+    runAsNonRoot: true
+
 # Local-only for now, per explicit instruction -- no B2 leg yet. Run
 # shortly after the webroot/database backup's coordinated 03:00-03:12
 # maintenance window (see docs/runbooks/nextcloud-restore.md) rather than


### PR DESCRIPTION
## Summary
Follow-up to #294 (adding local backup for the NFS user-file-data PVC) — the backup failed live, twice, before this fix:

1. **root_squash permission denied**: the default VolSync mover uid can't read `www-data`-owned files on the `synology-nfs-storage` export. Fixed with `moverSecurityContext: { runAsUser: 33, runAsGroup: 33 }`.
2. **SCC rejection**: OpenShift then rejected uid 33 outright (namespace's default SCC range is `1001030000-1001039999`). Fixed by binding VolSync's auto-created `volsync-src-data-nfs-backup` ServiceAccount to the same `anyuid` SCC the main Nextcloud app already uses.

Verified live before committing: manual backup run completed successfully — 470 files, 262 MiB, restic snapshot saved.

## Test plan
- [x] Manual trigger of `data-nfs-backup` completes successfully (already verified live)
- [ ] Confirm the 03:15 scheduled run also succeeds tonight

🤖 Generated with [Claude Code](https://claude.com/claude-code)