### PR TITLE
feat(tymeslot): add self-hosted booking page on Altus

### DIFF
--- a/bootstrap/overlays/local.home/values-apps.yaml
+++ b/bootstrap/overlays/local.home/values-apps.yaml
@@ -75,6 +75,11 @@ applications:
       argocd.argoproj.io/sync-wave: "300"
     source:
       path: components-apps/vaultwarden
+  tymeslot:
+    annotations:
+      argocd.argoproj.io/sync-wave: "300"
+    source:
+      path: components-apps/tymeslot
   paperless:
     annotations:
       argocd.argoproj.io/sync-wave: "300"

--- a/components-apps/tymeslot/anyuid-rolebinding.yaml
+++ b/components-apps/tymeslot/anyuid-rolebinding.yaml
@@ -1,0 +1,14 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: tymeslot-anyuid
+  annotations:
+    argocd.argoproj.io/sync-wave: "30"
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: tymeslot
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: "system:openshift:scc:anyuid"

--- a/components-apps/tymeslot/backup/data/backblaze-secret.yaml
+++ b/components-apps/tymeslot/backup/data/backblaze-secret.yaml
@@ -1,0 +1,7 @@
+- op: replace
+  path: /spec/target/name
+  value: restic-config-data-b2
+
+- op: replace
+  path: /spec/data/0/remoteRef/key
+  value: TYMESLOT_DATA_REPO

--- a/components-apps/tymeslot/backup/data/backblaze.yaml
+++ b/components-apps/tymeslot/backup/data/backblaze.yaml
@@ -1,0 +1,7 @@
+- op: replace
+  path: /spec/sourcePVC
+  value: tymeslot-app-data
+
+- op: replace
+  path: /spec/restic/repository
+  value: restic-config-data-b2

--- a/components-apps/tymeslot/backup/data/kustomization.yaml
+++ b/components-apps/tymeslot/backup/data/kustomization.yaml
@@ -1,0 +1,38 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namePrefix: data-
+namespace: tymeslot
+
+resources:
+  - ../../../../templates/volsync/rest
+  - ../../../../templates/volsync/backblaze
+
+patches:
+  - target:
+      group: volsync.backube
+      version: v1alpha1
+      kind: ReplicationSource
+      name: backup
+    path: local.yaml
+
+  - target:
+      group: external-secrets.io
+      version: v1
+      kind: ExternalSecret
+      name: external-restic-config
+    path: local-secret.yaml
+
+  - target:
+      group: volsync.backube
+      version: v1alpha1
+      kind: ReplicationSource
+      name: backup-b2
+    path: backblaze.yaml
+
+  - target:
+      group: external-secrets.io
+      version: v1
+      kind: ExternalSecret
+      name: external-restic-config-b2
+    path: backblaze-secret.yaml

--- a/components-apps/tymeslot/backup/data/local-secret.yaml
+++ b/components-apps/tymeslot/backup/data/local-secret.yaml
@@ -1,0 +1,7 @@
+- op: replace
+  path: /spec/target/name
+  value: restic-config-data
+
+- op: replace
+  path: /spec/data/0/remoteRef/key
+  value: TYMESLOT_DATA_REST_REPO_LOCAL

--- a/components-apps/tymeslot/backup/data/local.yaml
+++ b/components-apps/tymeslot/backup/data/local.yaml
@@ -1,0 +1,7 @@
+- op: replace
+  path: /spec/sourcePVC
+  value: tymeslot-app-data
+
+- op: replace
+  path: /spec/restic/repository
+  value: restic-config-data

--- a/components-apps/tymeslot/backup/database/backblaze-secret.yaml
+++ b/components-apps/tymeslot/backup/database/backblaze-secret.yaml
@@ -1,0 +1,7 @@
+- op: replace
+  path: /spec/target/name
+  value: restic-config-database-b2
+
+- op: replace
+  path: /spec/data/0/remoteRef/key
+  value: TYMESLOT_DATABASE_REPO

--- a/components-apps/tymeslot/backup/database/backblaze.yaml
+++ b/components-apps/tymeslot/backup/database/backblaze.yaml
@@ -1,0 +1,7 @@
+- op: replace
+  path: /spec/sourcePVC
+  value: database-syno-db-backup
+
+- op: replace
+  path: /spec/restic/repository
+  value: restic-config-database-b2

--- a/components-apps/tymeslot/backup/database/cron.yaml
+++ b/components-apps/tymeslot/backup/database/cron.yaml
@@ -1,0 +1,14 @@
+- op: replace
+  path: /spec/jobTemplate/spec/template/spec/volumes/0/persistentVolumeClaim/claimName
+  value: database-syno-db-backup
+
+- op: replace
+  path: /spec/jobTemplate/spec/template/spec/containers/0/env
+  value:
+    - name: POSTGRES_USER
+      value: tymeslot
+    - name: POSTGRES_POSTGRES_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: tymeslot-db-tymeslot-secret
+          key: password

--- a/components-apps/tymeslot/backup/database/kustomization.yaml
+++ b/components-apps/tymeslot/backup/database/kustomization.yaml
@@ -1,0 +1,53 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namePrefix: database-
+namespace: tymeslot
+
+resources:
+  - ../../../../templates/psql-backup
+  - ../../../../templates/volsync/rest
+  - ../../../../templates/volsync/backblaze
+
+patches:
+  - target:
+      group: volsync.backube
+      version: v1alpha1
+      kind: ReplicationSource
+      name: backup
+    path: local.yaml
+
+  - target:
+      group: external-secrets.io
+      version: v1
+      kind: ExternalSecret
+      name: external-restic-config
+    path: local-secret.yaml
+
+  - target:
+      group: volsync.backube
+      version: v1alpha1
+      kind: ReplicationSource
+      name: backup-b2
+    path: backblaze.yaml
+
+  - target:
+      group: external-secrets.io
+      version: v1
+      kind: ExternalSecret
+      name: external-restic-config-b2
+    path: backblaze-secret.yaml
+
+  - target:
+      group: batch
+      version: v1
+      kind: CronJob
+      name: psql-backup
+    path: cron.yaml
+
+  - target:
+      group: rbac.authorization.k8s.io
+      version: v1
+      kind: RoleBinding
+      name: psql-backup
+    path: rolebinding.yaml

--- a/components-apps/tymeslot/backup/database/local-secret.yaml
+++ b/components-apps/tymeslot/backup/database/local-secret.yaml
@@ -1,0 +1,7 @@
+- op: replace
+  path: /spec/target/name
+  value: restic-config-database
+
+- op: replace
+  path: /spec/data/0/remoteRef/key
+  value: TYMESLOT_DATABASE_REST_REPO_LOCAL

--- a/components-apps/tymeslot/backup/database/local.yaml
+++ b/components-apps/tymeslot/backup/database/local.yaml
@@ -1,0 +1,7 @@
+- op: replace
+  path: /spec/sourcePVC
+  value: database-syno-db-backup
+
+- op: replace
+  path: /spec/restic/repository
+  value: restic-config-database

--- a/components-apps/tymeslot/backup/database/rolebinding.yaml
+++ b/components-apps/tymeslot/backup/database/rolebinding.yaml
@@ -1,0 +1,6 @@
+- op: replace
+  path: /subjects
+  value:
+    - kind: ServiceAccount
+      name: database-psql-backup
+      namespace: tymeslot

--- a/components-apps/tymeslot/backup/kustomization.yaml
+++ b/components-apps/tymeslot/backup/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ./data
+  - ./database

--- a/components-apps/tymeslot/external-tymeslot-credentials.yaml
+++ b/components-apps/tymeslot/external-tymeslot-credentials.yaml
@@ -1,0 +1,41 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: external-tymeslot-credentials
+  namespace: tymeslot
+  annotations:
+    argocd.argoproj.io/sync-wave: "30"
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: doppler-cluster
+  target:
+    name: tymeslot-credentials
+  data:
+    - secretKey: secret-key-base
+      remoteRef:
+        key: TYMESLOT_SECRET_KEY_BASE
+    - secretKey: data-encryption-key
+      remoteRef:
+        key: TYMESLOT_DATA_ENCRYPTION_KEY
+    - secretKey: db-url
+      remoteRef:
+        key: TYMESLOT_DB_URL
+    - secretKey: smtp-host
+      remoteRef:
+        key: MAIL_HOST
+    - secretKey: smtp-username
+      remoteRef:
+        key: MAIL_USERNAME
+    - secretKey: smtp-password
+      remoteRef:
+        key: MAIL_PASSWORD
+    - secretKey: smtp-from
+      remoteRef:
+        key: MAIL_FROM
+    - secretKey: google-client-id
+      remoteRef:
+        key: TYMESLOT_GOOGLE_CLIENT_ID
+    - secretKey: google-client-secret
+      remoteRef:
+        key: TYMESLOT_GOOGLE_CLIENT_SECRET

--- a/components-apps/tymeslot/external-tymeslot-db-owner.yaml
+++ b/components-apps/tymeslot/external-tymeslot-db-owner.yaml
@@ -1,0 +1,24 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: tymeslot-db-tymeslot-secret
+  namespace: tymeslot
+  annotations:
+    argocd.argoproj.io/sync-wave: "30"
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: doppler-cluster
+  target:
+    name: tymeslot-db-tymeslot-secret
+    template:
+      engineVersion: v2
+      type: kubernetes.io/basic-auth
+      data:
+        username: "tymeslot"
+        password: "{{ .password }}"
+
+  data:
+    - secretKey: password
+      remoteRef:
+        key: TYMESLOT_POSTGRES_USER_PASSWORD

--- a/components-apps/tymeslot/external-tymeslot-db-superuser.yaml
+++ b/components-apps/tymeslot/external-tymeslot-db-superuser.yaml
@@ -1,0 +1,24 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: tymeslot-db-postgres-secret
+  namespace: tymeslot
+  annotations:
+    argocd.argoproj.io/sync-wave: "30"
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: doppler-cluster
+  target:
+    name: tymeslot-db-postgres-secret
+    template:
+      engineVersion: v2
+      type: kubernetes.io/basic-auth
+      data:
+        username: "postgres"
+        password: "{{ .password }}"
+
+  data:
+    - secretKey: password
+      remoteRef:
+        key: TYMESLOT_POSTGRES_POSTGRES_PASSWORD

--- a/components-apps/tymeslot/kustomization.yaml
+++ b/components-apps/tymeslot/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ./backup
+
+  - namespace.yaml
+  - anyuid-rolebinding.yaml
+  - postgresql-database.yaml
+  - external-tymeslot-db-superuser.yaml
+  - external-tymeslot-db-owner.yaml
+  - external-tymeslot-credentials.yaml
+  - tymeslot-chart-app.yaml

--- a/components-apps/tymeslot/namespace.yaml
+++ b/components-apps/tymeslot/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+  name: tymeslot

--- a/components-apps/tymeslot/postgresql-database.yaml
+++ b/components-apps/tymeslot/postgresql-database.yaml
@@ -1,0 +1,23 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: tymeslot-db
+  namespace: tymeslot
+  annotations:
+    argocd.argoproj.io/sync-wave: "100"
+spec:
+  instances: 1
+  enablePDB: false
+
+  superuserSecret:
+    name: tymeslot-db-postgres-secret
+
+  bootstrap:
+    initdb:
+      database: tymeslot
+      owner: tymeslot
+      secret:
+        name: tymeslot-db-tymeslot-secret
+
+  storage:
+    size: 2Gi

--- a/components-apps/tymeslot/tymeslot-chart-app.yaml
+++ b/components-apps/tymeslot/tymeslot-chart-app.yaml
@@ -1,0 +1,121 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "111"
+  name: tymeslot-app
+  namespace: openshift-gitops
+spec:
+  destination:
+    namespace: tymeslot
+    server: "https://kubernetes.default.svc"
+  source:
+    chart: app-template
+    repoURL: https://bjw-s-labs.github.io/helm-charts
+    targetRevision: 5.0.1
+    helm:
+      values: |-
+
+        defaultPodOptions:
+          securityContext:
+            runAsUser: 0
+            runAsGroup: 0
+
+        controllers:
+          tymeslot:
+            containers:
+              tymeslot:
+                image:
+                  repository: luka1thb/tymeslot
+                  tag: "1.7.0"
+                  pullPolicy: IfNotPresent
+                env:
+                  TZ: Europe/Berlin
+                  DEPLOYMENT_TYPE: docker
+                  PHX_HOST: book.janz.digital
+                  EMAIL_ADAPTER: smtp
+                  SMTP_PORT: 587
+                  ENABLE_GOOGLE_AUTH: "false"
+                  SECRET_KEY_BASE:
+                    valueFrom:
+                      secretKeyRef:
+                        name: tymeslot-credentials
+                        key: secret-key-base
+                  DATA_ENCRYPTION_KEY:
+                    valueFrom:
+                      secretKeyRef:
+                        name: tymeslot-credentials
+                        key: data-encryption-key
+                  DATABASE_URL:
+                    valueFrom:
+                      secretKeyRef:
+                        name: tymeslot-credentials
+                        key: db-url
+                  SMTP_HOST:
+                    valueFrom:
+                      secretKeyRef:
+                        name: tymeslot-credentials
+                        key: smtp-host
+                  SMTP_USERNAME:
+                    valueFrom:
+                      secretKeyRef:
+                        name: tymeslot-credentials
+                        key: smtp-username
+                  SMTP_PASSWORD:
+                    valueFrom:
+                      secretKeyRef:
+                        name: tymeslot-credentials
+                        key: smtp-password
+                  EMAIL_FROM_ADDRESS:
+                    valueFrom:
+                      secretKeyRef:
+                        name: tymeslot-credentials
+                        key: smtp-from
+                  GOOGLE_CLIENT_ID:
+                    valueFrom:
+                      secretKeyRef:
+                        name: tymeslot-credentials
+                        key: google-client-id
+                  GOOGLE_CLIENT_SECRET:
+                    valueFrom:
+                      secretKeyRef:
+                        name: tymeslot-credentials
+                        key: google-client-secret
+
+        service:
+          tymeslot:
+            controller: tymeslot
+            ports:
+              http:
+                port: 4000
+
+        ingress:
+          tymeslot:
+            enabled: true
+            className: openshift-default
+            annotations:
+              route.openshift.io/termination: "edge"
+            hosts:
+              - host: tymeslot-app.apps.altus.janz.digital
+                paths:
+                  - path: /
+                    service:
+                      identifier: tymeslot
+                      port: http
+
+        persistence:
+          data:
+            enabled: true
+            globalMounts:
+              - path: /app/data
+            accessMode: ReadWriteOnce
+            storageClass: lvms-vg1
+            size: 5Gi
+
+  project: cluster-apps
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true
+    automated:
+      prune: true
+      selfHeal: true


### PR DESCRIPTION
## Summary
- Deploys Tymeslot (github.com/Tymeslot/tymeslot) to Altus to replace Nextcloud's own Appointments feature, which doesn't reliably respect external/subscribed calendars for conflict detection
- Syncs availability from Nextcloud CalDAV and Google Calendar simultaneously, exposes a public booking link at `book.janz.digital` via the existing home-k8s Cloudflare Tunnel (companion infra-ops PR/commit already applied)
- CNPG-backed Postgres (external DB mode verified via scratch test on Altus — confirmed no bundled-Postgres fallback), volsync backups for both the `/app/data` PVC and the database dump, both local + Backblaze B2 (new dedicated buckets: `volsync-tymeslot-data`, `volsync-tymeslot-database`)
- Google OAuth wiring is in place but shipped with `ENABLE_GOOGLE_AUTH=false` pending a manual Google Cloud OAuth client creation step (placeholder Doppler values in place)

## Test plan
- [ ] ArgoCD syncs `tymeslot`/`tymeslot-app` to Synced/Healthy
- [ ] `oc get pods -n tymeslot` — app + CNPG pods running, no bundled-Postgres startup errors in logs
- [ ] `oc get pvc -n tymeslot` — confirm real PVC name matches `tymeslot-app-data` used in backup manifests
- [ ] `curl -I https://book.janz.digital` from outside the home network returns a real response
- [ ] Complete manual Google OAuth client setup + Nextcloud CalDAV connection, then book a real test slot and confirm it lands on both calendars
- [ ] `oc get replicationsource -n tymeslot` shows successful syncs after first scheduled run

🤖 Generated with [Claude Code](https://claude.com/claude-code)