### PR TITLE
fix(tymeslot): correct backup sourcePVC to real PVC name

### DIFF
--- a/components-apps/tymeslot/backup/data/backblaze.yaml
+++ b/components-apps/tymeslot/backup/data/backblaze.yaml
@@ -1,6 +1,6 @@
 - op: replace
   path: /spec/sourcePVC
-  value: tymeslot-app-data
+  value: tymeslot-app
 
 - op: replace
   path: /spec/restic/repository

--- a/components-apps/tymeslot/backup/data/local.yaml
+++ b/components-apps/tymeslot/backup/data/local.yaml
@@ -1,6 +1,6 @@
 - op: replace
   path: /spec/sourcePVC
-  value: tymeslot-app-data
+  value: tymeslot-app
 
 - op: replace
   path: /spec/restic/repository


### PR DESCRIPTION
Follow-up to #298 — `oc get pvc -n tymeslot` shows the real PVC name is `tymeslot-app`, not `tymeslot-app-data`. Fixes the volsync backup sourcePVC references before they become a silent no-op.