### PR TITLE
fix(tymeslot): anyuid ClusterRoleBinding must target tymeslot-app SA

### DIFF
--- a/components-apps/tymeslot/anyuid-rolebinding.yaml
+++ b/components-apps/tymeslot/anyuid-rolebinding.yaml
@@ -6,7 +6,7 @@ metadata:
     argocd.argoproj.io/sync-wave: "30"
 subjects:
   - kind: ServiceAccount
-    name: default
+    name: tymeslot-app
     namespace: tymeslot
 roleRef:
   apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
Follow-up to #298 — the app-template chart's actual runtime ServiceAccount is `tymeslot-app`, not `default`. Confirmed live: the leaf pod failed SCC admission (`not usable by user or serviceaccount` for provider anyuid) until patched directly on-cluster; this makes that fix permanent in git.