### PR TITLE
feat(tymeslot): enable Google Calendar auth

### DIFF
--- a/components-apps/tymeslot/tymeslot-chart-app.yaml
+++ b/components-apps/tymeslot/tymeslot-chart-app.yaml
@@ -35,7 +35,7 @@ spec:
                   PHX_HOST: book.janz.digital
                   EMAIL_ADAPTER: smtp
                   SMTP_PORT: 587
-                  ENABLE_GOOGLE_AUTH: "false"
+                  ENABLE_GOOGLE_AUTH: "true"
                   SECRET_KEY_BASE:
                     valueFrom:
                       secretKeyRef:


### PR DESCRIPTION
Google OAuth client is now configured in Doppler; flips ENABLE_GOOGLE_AUTH to true so users can connect Google Calendar from the Tymeslot UI.