### PR TITLE
fix(tymeslot): add missing GOOGLE_STATE_SECRET env var

### DIFF
--- a/components-apps/tymeslot/external-tymeslot-credentials.yaml
+++ b/components-apps/tymeslot/external-tymeslot-credentials.yaml
@@ -39,3 +39,6 @@ spec:
     - secretKey: google-client-secret
       remoteRef:
         key: TYMESLOT_GOOGLE_CLIENT_SECRET
+    - secretKey: google-state-secret
+      remoteRef:
+        key: TYMESLOT_GOOGLE_STATE_SECRET

--- a/components-apps/tymeslot/tymeslot-chart-app.yaml
+++ b/components-apps/tymeslot/tymeslot-chart-app.yaml
@@ -81,6 +81,11 @@ spec:
                       secretKeyRef:
                         name: tymeslot-credentials
                         key: google-client-secret
+                  GOOGLE_STATE_SECRET:
+                    valueFrom:
+                      secretKeyRef:
+                        name: tymeslot-credentials
+                        key: google-state-secret
 
         service:
           tymeslot:


### PR DESCRIPTION
Google OAuth requires GOOGLE_STATE_SECRET alongside client id/secret — Tymeslot's UI reported "Google OAuth is not configured" until this was set. Generated and stored as TYMESLOT_GOOGLE_STATE_SECRET in Doppler.