### PR TITLE
feat(recordbuddy-worker): deploy remote ASR worker to sakaar-sno

### DIFF
--- a/bootstrap/overlays/sakaar/values-apps.yaml
+++ b/bootstrap/overlays/sakaar/values-apps.yaml
@@ -39,3 +39,8 @@ applications:
       argocd.argoproj.io/sync-wave: "200"
     source:
       path: components-apps/cloudnative-pg
+  recordbuddy-worker:
+    annotations:
+      argocd.argoproj.io/sync-wave: "300"
+    source:
+      path: components-apps/recordbuddy-worker

--- a/components-apps/recordbuddy-worker/external-recordbuddy-worker-ghcr-pull.yaml
+++ b/components-apps/recordbuddy-worker/external-recordbuddy-worker-ghcr-pull.yaml
@@ -1,0 +1,23 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: recordbuddy-worker-ghcr-pull-secret
+  namespace: recordbuddy-worker
+  annotations:
+    argocd.argoproj.io/sync-wave: "30"
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: doppler-cluster
+  target:
+    name: recordbuddy-worker-ghcr-pull-secret
+    template:
+      engineVersion: v2
+      type: kubernetes.io/dockerconfigjson
+      data:
+        .dockerconfigjson: |
+          {"auths":{"ghcr.io":{"username":"PixelJonas","password":"{{ .token }}","auth":"{{ printf "PixelJonas:%s" .token | b64enc }}"}}}
+  data:
+    - secretKey: token
+      remoteRef:
+        key: TAXBUDDY_GHCR_PULL_TOKEN

--- a/components-apps/recordbuddy-worker/external-recordbuddy-worker-secret.yaml
+++ b/components-apps/recordbuddy-worker/external-recordbuddy-worker-secret.yaml
@@ -1,0 +1,17 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: recordbuddy-worker-credentials
+  namespace: recordbuddy-worker
+  annotations:
+    argocd.argoproj.io/sync-wave: "30"
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: doppler-cluster
+  target:
+    name: recordbuddy-worker-credentials
+  data:
+    - secretKey: RECORDBUDDY_WORKER_SECRET
+      remoteRef:
+        key: RECORDBUDDY_WORKER_API_SECRET

--- a/components-apps/recordbuddy-worker/kustomization.yaml
+++ b/components-apps/recordbuddy-worker/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - namespace.yaml
+  - external-recordbuddy-worker-secret.yaml
+  - external-recordbuddy-worker-ghcr-pull.yaml
+  - recordbuddy-worker-app.yaml

--- a/components-apps/recordbuddy-worker/namespace.yaml
+++ b/components-apps/recordbuddy-worker/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+  name: recordbuddy-worker

--- a/components-apps/recordbuddy-worker/recordbuddy-worker-app.yaml
+++ b/components-apps/recordbuddy-worker/recordbuddy-worker-app.yaml
@@ -1,0 +1,91 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "111"
+  name: recordbuddy-worker-app
+  namespace: openshift-gitops
+spec:
+  destination:
+    namespace: recordbuddy-worker
+    server: "https://kubernetes.default.svc"
+  source:
+    chart: app-template
+    repoURL: https://bjw-s-labs.github.io/helm-charts
+    targetRevision: 5.0.1
+    helm:
+      values: |-
+        defaultPodOptions:
+          imagePullSecrets:
+            - name: recordbuddy-worker-ghcr-pull-secret
+
+        controllers:
+          recordbuddy-worker:
+            containers:
+              recordbuddy-worker:
+                image:
+                  repository: ghcr.io/pixeljonas/recordbuddy-worker
+                  tag: latest
+                  pullPolicy: Always
+                env:
+                  RECORDBUDDY_WORKER_MODEL: large-v3
+                  RECORDBUDDY_WORKER_DEVICE: cpu
+                  RECORDBUDDY_WORKER_COMPUTE_TYPE: int8
+                  RECORDBUDDY_WORKER_SECRET:
+                    valueFrom:
+                      secretKeyRef:
+                        name: recordbuddy-worker-credentials
+                        key: RECORDBUDDY_WORKER_SECRET
+                resources:
+                  requests:
+                    cpu: "4"
+                    memory: 6Gi
+                  limits:
+                    cpu: "6"
+                    memory: 8Gi
+                probes:
+                  liveness:
+                    enabled: true
+                    custom: true
+                    spec:
+                      httpGet:
+                        path: /v1/healthz
+                        port: 9878
+                      initialDelaySeconds: 30
+                      periodSeconds: 15
+                  readiness:
+                    enabled: true
+                    custom: true
+                    spec:
+                      httpGet:
+                        path: /v1/healthz
+                        port: 9878
+                      initialDelaySeconds: 10
+                      periodSeconds: 10
+
+        service:
+          recordbuddy-worker:
+            controller: recordbuddy-worker
+            annotations:
+              tailscale.com/expose: "true"
+              tailscale.com/hostname: "recordbuddy-worker"
+            ports:
+              http:
+                port: 9878
+
+        persistence:
+          models:
+            enabled: true
+            accessMode: ReadWriteOnce
+            storageClass: lvms-vg1
+            size: 10Gi
+            globalMounts:
+              - path: /models
+
+  project: cluster-apps
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true
+    automated:
+      prune: true
+      selfHeal: true


### PR DESCRIPTION
## Summary
- New `recordbuddy-worker` component (`components-apps/recordbuddy-worker/`), wired into sakaar-sno only via `bootstrap/overlays/sakaar/values-apps.yaml`
- Mirrors the litellm/docling-serve bjw-s app-template pattern: `ghcr.io/pixeljonas/recordbuddy-worker:latest`, `RECORDBUDDY_WORKER_MODEL=large-v3` (cpu/int8), 4-6 CPU / 6-8Gi memory, 10Gi PVC (`lvms-vg1`) for the HuggingFace weight cache at `/models`
- Bearer secret synced via the existing `doppler-cluster` ClusterSecretStore from `RECORDBUDDY_WORKER_API_SECRET` (already created in Doppler `homelab`/`home`)
- GHCR pull secret reuses the existing `TAXBUDDY_GHCR_PULL_TOKEN`
- Exposed via the Tailscale K8s operator (`tailscale.com/expose`/`hostname` annotations) — no public Route, matching the current asgard worker's tailnet-only exposure model

## Why
asgard's podman VM is capped at 6 GiB, which forced the worker onto faster-whisper's `small` model. That model hallucinates repeated filler ("Mhm.") on lower-SNR audio instead of transcribing real speech — confirmed on a real 61-minute recording where the self/mic track came back 98% filler despite audible speech underneath. sakaar-sno has ~75 GiB of free headroom right now, comfortably fitting `large-v3` (the orchestrator's own local-backend default model).

altus was considered as a fallback target but is deferred — it currently has a pre-existing, unrelated TopoLVM XFS read-only remount issue that would break any new PVC-backed workload there.

## Test plan
- [x] `kustomize build components-apps/recordbuddy-worker` renders cleanly
- [x] `kustomize build --enable-helm bootstrap/overlays/sakaar` includes the new Application, sourced from the right path
- [x] `RECORDBUDDY_WORKER_API_SECRET` confirmed present in Doppler `homelab`/`home` (name-only check, no value exposure)
- [ ] After merge: confirm the pod comes up `Running`/`Ready` on sakaar-sno and `GET /v1/healthz` (over Tailscale) reports `model: "large-v3"`
- [ ] Point `worker_url` at the new Tailscale hostname from the RecordBuddy app's Settings (Advanced tab), run a real recording, confirm the self track transcribes real speech

🤖 Generated with [Claude Code](https://claude.com/claude-code)