### PR TITLE
feat(recordbuddy-worker-de): deploy German-specialized ASR worker to sakaar-sno

### DIFF
--- a/bootstrap/overlays/sakaar/values-apps.yaml
+++ b/bootstrap/overlays/sakaar/values-apps.yaml
@@ -44,3 +44,8 @@ applications:
       argocd.argoproj.io/sync-wave: "300"
     source:
       path: components-apps/recordbuddy-worker
+  recordbuddy-worker-de:
+    annotations:
+      argocd.argoproj.io/sync-wave: "300"
+    source:
+      path: components-apps/recordbuddy-worker-de

--- a/components-apps/recordbuddy-worker-de/external-recordbuddy-worker-de-ghcr-pull.yaml
+++ b/components-apps/recordbuddy-worker-de/external-recordbuddy-worker-de-ghcr-pull.yaml
@@ -1,0 +1,23 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: recordbuddy-worker-de-ghcr-pull-secret
+  namespace: recordbuddy-worker-de
+  annotations:
+    argocd.argoproj.io/sync-wave: "30"
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: doppler-cluster
+  target:
+    name: recordbuddy-worker-de-ghcr-pull-secret
+    template:
+      engineVersion: v2
+      type: kubernetes.io/dockerconfigjson
+      data:
+        .dockerconfigjson: |
+          {"auths":{"ghcr.io":{"username":"PixelJonas","password":"{{ .token }}","auth":"{{ printf "PixelJonas:%s" .token | b64enc }}"}}}
+  data:
+    - secretKey: token
+      remoteRef:
+        key: TAXBUDDY_GHCR_PULL_TOKEN

--- a/components-apps/recordbuddy-worker-de/external-recordbuddy-worker-de-secret.yaml
+++ b/components-apps/recordbuddy-worker-de/external-recordbuddy-worker-de-secret.yaml
@@ -1,0 +1,20 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: recordbuddy-worker-de-credentials
+  namespace: recordbuddy-worker-de
+  annotations:
+    argocd.argoproj.io/sync-wave: "30"
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: doppler-cluster
+  target:
+    name: recordbuddy-worker-de-credentials
+  data:
+    # Same bearer token as recordbuddy-worker: the orchestrator client sends
+    # one secret regardless of which worker URL it calls (language routing
+    # picks the URL, not a different credential).
+    - secretKey: RECORDBUDDY_WORKER_SECRET
+      remoteRef:
+        key: RECORDBUDDY_WORKER_API_SECRET

--- a/components-apps/recordbuddy-worker-de/kustomization.yaml
+++ b/components-apps/recordbuddy-worker-de/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - namespace.yaml
+  - external-recordbuddy-worker-de-secret.yaml
+  - external-recordbuddy-worker-de-ghcr-pull.yaml
+  - recordbuddy-worker-de-app.yaml

--- a/components-apps/recordbuddy-worker-de/namespace.yaml
+++ b/components-apps/recordbuddy-worker-de/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+  name: recordbuddy-worker-de

--- a/components-apps/recordbuddy-worker-de/recordbuddy-worker-de-app.yaml
+++ b/components-apps/recordbuddy-worker-de/recordbuddy-worker-de-app.yaml
@@ -1,0 +1,95 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "111"
+  name: recordbuddy-worker-de-app
+  namespace: openshift-gitops
+spec:
+  destination:
+    namespace: recordbuddy-worker-de
+    server: "https://kubernetes.default.svc"
+  source:
+    chart: app-template
+    repoURL: https://bjw-s-labs.github.io/helm-charts
+    targetRevision: 5.0.1
+    helm:
+      values: |-
+        defaultPodOptions:
+          imagePullSecrets:
+            - name: recordbuddy-worker-de-ghcr-pull-secret
+
+        controllers:
+          recordbuddy-worker-de:
+            containers:
+              recordbuddy-worker-de:
+                image:
+                  repository: ghcr.io/pixeljonas/recordbuddy-worker
+                  tag: latest
+                  pullPolicy: Always
+                env:
+                  # German-specialized model (ADR-0014): a primeline
+                  # large-v3 fine-tune, community-converted to CTranslate2.
+                  # Same image as recordbuddy-worker — only the model
+                  # differs. cc-by-nc-4.0 licensed.
+                  RECORDBUDDY_WORKER_MODEL: Reality-Interface/whisper-large-v3-german-faster-whisper
+                  RECORDBUDDY_WORKER_DEVICE: cpu
+                  RECORDBUDDY_WORKER_COMPUTE_TYPE: int8
+                  RECORDBUDDY_WORKER_SECRET:
+                    valueFrom:
+                      secretKeyRef:
+                        name: recordbuddy-worker-de-credentials
+                        key: RECORDBUDDY_WORKER_SECRET
+                resources:
+                  requests:
+                    cpu: "4"
+                    memory: 6Gi
+                  limits:
+                    cpu: "6"
+                    memory: 8Gi
+                probes:
+                  liveness:
+                    enabled: true
+                    custom: true
+                    spec:
+                      httpGet:
+                        path: /v1/healthz
+                        port: 9878
+                      initialDelaySeconds: 30
+                      periodSeconds: 15
+                  readiness:
+                    enabled: true
+                    custom: true
+                    spec:
+                      httpGet:
+                        path: /v1/healthz
+                        port: 9878
+                      initialDelaySeconds: 10
+                      periodSeconds: 10
+
+        service:
+          recordbuddy-worker-de:
+            controller: recordbuddy-worker-de
+            annotations:
+              tailscale.com/expose: "true"
+              tailscale.com/hostname: "recordbuddy-worker-de"
+            ports:
+              http:
+                port: 9878
+
+        persistence:
+          models:
+            enabled: true
+            accessMode: ReadWriteOnce
+            storageClass: lvms-vg1
+            size: 10Gi
+            globalMounts:
+              - path: /models
+
+  project: cluster-apps
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true
+    automated:
+      prune: true
+      selfHeal: true


### PR DESCRIPTION
## Summary
- New `recordbuddy-worker-de` component (`components-apps/recordbuddy-worker-de/`), wired into sakaar-sno only via `bootstrap/overlays/sakaar/values-apps.yaml`
- Same image as `recordbuddy-worker` (`ghcr.io/pixeljonas/recordbuddy-worker:latest`), running `RECORDBUDDY_WORKER_MODEL=Reality-Interface/whisper-large-v3-german-faster-whisper` (a primeline `large-v3` fine-tune for German, community-converted to CTranslate2) instead of generic `large-v3`
- Reuses the existing `RECORDBUDDY_WORKER_API_SECRET` bearer token (same secret across both workers — the orchestrator client picks the URL by language, not a different credential)
- Own namespace, 10Gi PVC (`lvms-vg1`), and Tailscale hostname (`recordbuddy-worker-de`) for isolation from the primary worker

## Why
RecordBuddy's orchestrator now supports routing the transcribe stage to a different worker URL based on the session's declared language (`worker_url_de` config key / `RECORDBUDDY_WORKER_URL_DE` env var — see `recordbuddy` repo commit `81953ac`). This deployment is the German-specialized target for that routing. The model is `cc-by-nc-4.0` licensed; the repo owner has made their own call that transcribing their own business meetings is acceptable non-commercial use under Creative Commons' use-focused test.

## Test plan
- [x] `kustomize build components-apps/recordbuddy-worker-de` renders cleanly
- [x] `kustomize build --enable-helm bootstrap/overlays/sakaar` includes the new Application
- [ ] After merge: confirm the pod comes up `Running`/`Ready` and `GET /v1/healthz` (over Tailscale) reports the German model
- [ ] Submit a real German transcribe job and confirm real German output (not just healthz)
- [ ] Add `worker_url_de` to jjanz1-mac's `config.toml` once the Tailscale IP is known

🤖 Generated with [Claude Code](https://claude.com/claude-code)