### PR TITLE
feat(hermes-argocd-agent): add write-scoped ArgoCD refresh RBAC for Heimdall

### DIFF
--- a/bootstrap/overlays/local.home/values-infra.yaml
+++ b/bootstrap/overlays/local.home/values-infra.yaml
@@ -134,6 +134,12 @@ applications:
     source:
       path: components-infra/hermes-upgrade-agent/base
 
+  hermes-argocd-agent:
+    annotations:
+      argocd.argoproj.io/sync-wave: "11"
+    source:
+      path: components-infra/hermes-argocd-agent/base
+
   cloudflared:
     annotations:
       argocd.argoproj.io/sync-wave: "22"

--- a/bootstrap/overlays/sakaar/values-infra.yaml
+++ b/bootstrap/overlays/sakaar/values-infra.yaml
@@ -72,6 +72,12 @@ applications:
     source:
       path: components-infra/hermes-upgrade-agent/base
 
+  hermes-argocd-agent:
+    annotations:
+      argocd.argoproj.io/sync-wave: "11"
+    source:
+      path: components-infra/hermes-argocd-agent/base
+
   rbac:
     annotations:
       argocd.argoproj.io/compare-options: IgnoreExtraneous

--- a/components-infra/hermes-argocd-agent/base/clusterrole.yaml
+++ b/components-infra/hermes-argocd-agent/base/clusterrole.yaml
@@ -1,0 +1,34 @@
+# Deliberately a SEPARATE ClusterRole/ServiceAccount from hermes-infra-read
+# (components-infra/hermes-infra-agent/base) and from hermes-upgrade-trigger
+# (components-infra/hermes-upgrade-agent/base), following the same rationale
+# as the latter: a credential that can write anything is a fundamentally
+# different risk tier from the read-only investigate credential every other
+# MCP tool call relies on day-to-day. Keeping it separate means a bug, leak,
+# or compromise of the routine read-only credential can never reach this
+# one, and this narrow write credential doesn't sit in the blast radius of
+# ordinary diagnostic requests.
+#
+# Scope is intentionally as narrow as Kubernetes RBAC can express: get/list/
+# watch/patch on argoproj.io Applications ONLY, cluster-wide (matches
+# hermes-infra-read's cluster-scoped shape rather than a namespaced Role, for
+# consistency with the rest of this agent's credentials). No delete, no
+# create, no other resource — in particular no Deployments, so this
+# credential cannot restart openshift-gitops-repo-server.
+#
+# `patch` here structurally permits more than a refresh annotation -- it
+# also allows writing `.operation.sync`, i.e. triggering a sync, not just
+# invalidating the manifest cache. RBAC cannot narrow that further (there is
+# no "patch, but only this one annotation key" verb). The restriction to
+# *only* the argocd.argoproj.io/refresh=hard annotation is enforced in the
+# MCP server implementation (mcp-servers/infra-gitops/server.py in
+# infra-ops), not by this ClusterRole -- same two-layer model as
+# hermes-upgrade-trigger's clusterversion-value restriction.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: hermes-argocd-refresh
+rules:
+  - apiGroups: ["argoproj.io"]
+    resources:
+      - applications
+    verbs: ["get", "list", "watch", "patch"]

--- a/components-infra/hermes-argocd-agent/base/clusterrolebinding.yaml
+++ b/components-infra/hermes-argocd-agent/base/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: hermes-argocd-agent-refresh-binding
+subjects:
+  - kind: ServiceAccount
+    name: hermes-argocd-agent
+    namespace: hermes-infra
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: hermes-argocd-refresh

--- a/components-infra/hermes-argocd-agent/base/kustomization.yaml
+++ b/components-infra/hermes-argocd-agent/base/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - serviceaccount.yaml
+  - clusterrole.yaml
+  - clusterrolebinding.yaml
+  - secret.yaml

--- a/components-infra/hermes-argocd-agent/base/secret.yaml
+++ b/components-infra/hermes-argocd-agent/base/secret.yaml
@@ -1,0 +1,15 @@
+# Same pattern as components-infra/hermes-infra-agent/base/secret.yaml and
+# components-infra/hermes-upgrade-agent/base/secret.yaml: a legacy-style
+# long-lived service-account token secret (the annotation triggers the
+# controller to auto-populate data.token/data.ca.crt; this manifest carries
+# no secret value itself). Intended to be synced out to Doppler as new
+# HERMES_ARGOCD_SAKAAR_KUBECONFIG / HERMES_ARGOCD_ALTUS_KUBECONFIG keys, as a
+# manual step -- Heimdall cannot write Doppler secret values itself.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hermes-argocd-agent-token
+  namespace: hermes-infra
+  annotations:
+    kubernetes.io/service-account.name: hermes-argocd-agent
+type: kubernetes.io/service-account-token

--- a/components-infra/hermes-argocd-agent/base/serviceaccount.yaml
+++ b/components-infra/hermes-argocd-agent/base/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: hermes-argocd-agent
+  namespace: hermes-infra


### PR DESCRIPTION
## Summary
- New component `components-infra/hermes-argocd-agent/base/`: ServiceAccount `hermes-argocd-agent` + ClusterRole `hermes-argocd-refresh` (get/list/watch/patch on `argoproj.io` Applications only — no Deployments, no other resource) + ClusterRoleBinding + long-lived SA token Secret.
- Deployed symmetrically to both cluster overlays (`sakaar`, `local.home`/altus), same sync-wave as the sibling `hermes-infra-agent`/`hermes-upgrade-agent` components.
- Follows the existing `hermes-upgrade-agent` precedent: a separate credential/risk-tier from the routine read-only `hermes-infra-read` agent, rather than widening that ClusterRole.

## Why
Backs a companion infra-ops PR (`infra-gitops` MCP server) letting Heimdall force an ArgoCD hard-refresh on a single named Application, instead of that always requiring a human (see `.claude/rules/kubernetes-argocd.md`'s documented manual procedure).

## Test plan
- [ ] Merge, confirm ArgoCD syncs the new component cleanly on both clusters (`oc get sa,clusterrole,clusterrolebinding -l ...` or just check the Application is Healthy)
- [ ] `oc auth can-i patch applications.argoproj.io -n openshift-gitops --as=system:serviceaccount:hermes-infra:hermes-argocd-agent` → yes, on both clusters
- [ ] `oc auth can-i patch deployments -n openshift-gitops --as=system:serviceaccount:hermes-infra:hermes-argocd-agent` → no (confirms it can't touch openshift-gitops-repo-server)
- [ ] Build kubeconfig from `hermes-argocd-agent-token`'s populated `token`/`ca.crt`, hand off to the infra-ops PR's manual Doppler step

🤖 Generated with [Claude Code](https://claude.com/claude-code)