### PR TITLE
fix(recordbuddy-worker-de): lower CPU request to fit sakaar-sno headroom

### DIFF
--- a/components-apps/recordbuddy-worker-de/recordbuddy-worker-de-app.yaml
+++ b/components-apps/recordbuddy-worker-de/recordbuddy-worker-de-app.yaml
@@ -41,8 +41,16 @@ spec:
                         name: recordbuddy-worker-de-credentials
                         key: RECORDBUDDY_WORKER_SECRET
                 resources:
+                  # Request lower than recordbuddy-worker's 4 CPU: sakaar-sno
+                  # (single node, 11.5 allocatable) only has ~1.9 CPU of
+                  # request headroom left after the primary worker and
+                  # existing workloads — confirmed via a Pending pod with
+                  # "Insufficient cpu" on first deploy (2026-08-15). The
+                  # limit stays high so it can still burst during an actual
+                  # transcription job; faster-whisper is bursty, not
+                  # continuously CPU-bound at idle.
                   requests:
-                    cpu: "4"
+                    cpu: "1500m"
                     memory: 6Gi
                   limits:
                     cpu: "6"


### PR DESCRIPTION
## Summary
- Lowers `recordbuddy-worker-de`'s CPU request from 4 to 1500m (limit unchanged at 6) so it actually fits sakaar-sno's remaining request headroom

## Why
The pod went Pending with "Insufficient cpu" on first deploy (#311) — sakaar-sno is single-node with 11.5 allocatable CPU, and `recordbuddy-worker`'s own 4 CPU request plus other existing workloads already consume ~9.6, leaving only ~1.9 free. The live pod currently reports Running/Ready via some out-of-band state, but that's undocumented drift from what's committed in git — ArgoCD's `selfHeal: true` will otherwise try to reconcile back toward the old 4-CPU-request value and re-break scheduling. This commit makes git the correct, working source of truth.

## Test plan
- [x] `kustomize build components-apps/recordbuddy-worker-de` renders the new value
- [ ] After merge: confirm the pod stays Running/Ready through ArgoCD's next sync (not just right now)
- [ ] Submit a real German transcribe job to confirm it still works under the lower CPU request

🤖 Generated with [Claude Code](https://claude.com/claude-code)