### PR TITLE
feat(recordbuddy-worker-de): authenticate to HuggingFace for the gated model repo

### DIFF
--- a/components-apps/recordbuddy-worker-de/external-recordbuddy-worker-de-hf-token.yaml
+++ b/components-apps/recordbuddy-worker-de/external-recordbuddy-worker-de-hf-token.yaml
@@ -1,0 +1,22 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: recordbuddy-worker-de-hf-token
+  namespace: recordbuddy-worker-de
+  annotations:
+    argocd.argoproj.io/sync-wave: "30"
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: doppler-cluster
+  target:
+    name: recordbuddy-worker-de-hf-token
+  data:
+    # The German model repo is gated on HuggingFace (accept-terms click,
+    # 2026-08-15) — faster-whisper's lazy weight download needs an
+    # authenticated, gate-accepted account's token. A dedicated key, not the
+    # shared HUGGINGFACE_TOKEN already in this Doppler config (used by other
+    # services with different access needs).
+    - secretKey: HF_TOKEN
+      remoteRef:
+        key: RECORDBUDDY_HUGGINGFACE_TOKEN

--- a/components-apps/recordbuddy-worker-de/kustomization.yaml
+++ b/components-apps/recordbuddy-worker-de/kustomization.yaml
@@ -5,4 +5,5 @@ resources:
   - namespace.yaml
   - external-recordbuddy-worker-de-secret.yaml
   - external-recordbuddy-worker-de-ghcr-pull.yaml
+  - external-recordbuddy-worker-de-hf-token.yaml
   - recordbuddy-worker-de-app.yaml

--- a/components-apps/recordbuddy-worker-de/recordbuddy-worker-de-app.yaml
+++ b/components-apps/recordbuddy-worker-de/recordbuddy-worker-de-app.yaml
@@ -40,6 +40,15 @@ spec:
                       secretKeyRef:
                         name: recordbuddy-worker-de-credentials
                         key: RECORDBUDDY_WORKER_SECRET
+                  # The model repo is gated on HuggingFace (accept-terms
+                  # click) — HF_TOKEN is huggingface_hub's current standard
+                  # env var for authenticated downloads (HUGGING_FACE_HUB_TOKEN
+                  # is the older alias; HF_TOKEN takes precedence).
+                  HF_TOKEN:
+                    valueFrom:
+                      secretKeyRef:
+                        name: recordbuddy-worker-de-hf-token
+                        key: HF_TOKEN
                 resources:
                   requests:
                     memory: 12Gi


### PR DESCRIPTION
## Summary
- Adds `HF_TOKEN` env var to `recordbuddy-worker-de`, sourced from a new ExternalSecret referencing Doppler `homelab`/`home`'s `RECORDBUDDY_HUGGINGFACE_TOKEN`

## Why
`Reality-Interface/whisper-large-v3-german-faster-whisper` is a gated HF repo (accept-terms click). A real end-to-end transcribe smoke test against the live worker failed on first weight download with `GatedRepoError: 401` — the account has since accepted the gate, and its token is now stored under a dedicated Doppler key (not the shared `HUGGINGFACE_TOKEN` already in this config, used by other services).

## Test plan
- [x] `kustomize build components-apps/recordbuddy-worker-de` renders the new ExternalSecret + env var
- [x] Token verified valid and gate-accepted (`whoami` + a direct authenticated file fetch both succeeded) before this PR
- [ ] After merge: resubmit a real German transcribe job and confirm it completes with real German text (previous attempt failed on the gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)