### PR TITLE
fix(resilio-sync): align PUID/PGID with actual NFS folder owner (1024:100)

### DIFF
--- a/components-apps/resilio-sync/resilio-sync-app.yaml
+++ b/components-apps/resilio-sync/resilio-sync-app.yaml
@@ -31,8 +31,8 @@ spec:
                   pullPolicy: IfNotPresent
                 env:
                   TZ: Europe/Berlin
-                  PUID: "1500"
-                  PGID: "1500"
+                  PUID: "1024"
+                  PGID: "100"
                 securityContext:
                   privileged: true
 


### PR DESCRIPTION
## Summary
- resilio-sync on Altus was running as uid 1500 (PUID/PGID), but the NFS-mounted sync folders under `/sync/jonas/*` and `/sync/joans/Camera backup` are owned `1024:100` (users), mode 755 (owner-write only)
- This caused recurring `unable to get write handle to mutex file, error 13` (EACCES) in the pod logs every ~15s for those folders
- uid 1024 is the real Synology DSM account that owns this data — the same identity the desktop/mobile Resilio clients already sync as
- Aligning `PUID`/`PGID` to `1024`/`100` fixes the mismatch without loosening any NFS permissions (avoids widening `.ssh` folder access via a `chmod g+w` alternative)

## Test plan
- [x] Confirmed via `oc exec` that the running `rslsync` process is uid 1500, gid 1500, supplementary group 100
- [x] Confirmed affected NFS dirs are owned 1024:100, mode 755 (no group-write)
- [ ] After merge/sync: verify pod recreates with new PUID/PGID and mutex EACCES errors stop in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)