### PR TITLE
fix(tymeslot): bump image to 1.9.0

### DIFF
--- a/components-apps/tymeslot/tymeslot-chart-app.yaml
+++ b/components-apps/tymeslot/tymeslot-chart-app.yaml
@@ -27,7 +27,7 @@ spec:
               tymeslot:
                 image:
                   repository: luka1thb/tymeslot
-                  tag: "1.7.0"
+                  tag: "1.9.0"
                   pullPolicy: IfNotPresent
                 env:
                   TZ: Europe/Berlin


### PR DESCRIPTION
## Summary
- Tymeslot's Nextcloud CalDAV connect flow (1.7.0) intermittently flaps `nextcloud_discovery_validation_failure` → `nextcloud_discovery_validation_success` for identical credentials within the same attempt, and never proceeds to the calendar discovery/selection step even on success (confirmed live via pod logs + DB inspection).
- No release note pins an exact fix, but 1.8.0/1.8.1/1.9.0 touch calendar integration code paths and it's a low-risk, reversible bump.

## Test plan
- [ ] ArgoCD syncs `tymeslot-app` and the new image pulls/starts healthy
- [ ] Retry connecting the Nextcloud CalDAV calendar in the Tymeslot UI
- [ ] Confirm calendars list populates and the "last synced" warning clears after a sync cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)