### PR TITLE
chore(devland-editor-agent): bump image to sha-ee70ec4

### DIFF
--- a/components-apps/devland-editor-agent/base/kustomization.yaml
+++ b/components-apps/devland-editor-agent/base/kustomization.yaml
@@ -16,4 +16,4 @@ resources:
 images:
   - name: ghcr.io/pixeljonas/devland-editor-agent
     newName: ghcr.io/pixeljonas/devland-editor-agent
-    digest: sha256:f9d03aef133910ad9a30dab9c550d09823fca65c3fef297c6dc664ff3e47cc16
+    digest: sha256:c0904156024d52f13d660bfe1156b3cb6bdac3069ae7fae833fc54d389c0058f


### PR DESCRIPTION
Automated digest bump from devland-editor-agent CI.

Digest: sha256:c0904156024d52f13d660bfe1156b3cb6bdac3069ae7fae833fc54d389c0058f
Source: https://github.com/PixelJonas/devland-editor-agent/commit/ee70ec40d6e305bf61699ec99d57ab6512542db4