### PR TITLE
chore(devland-editor-agent): bump image to sha-7b8632e

### DIFF
--- a/components-apps/devland-editor-agent/base/kustomization.yaml
+++ b/components-apps/devland-editor-agent/base/kustomization.yaml
@@ -16,4 +16,4 @@ resources:
 images:
   - name: ghcr.io/pixeljonas/devland-editor-agent
     newName: ghcr.io/pixeljonas/devland-editor-agent
-    digest: sha256:c0904156024d52f13d660bfe1156b3cb6bdac3069ae7fae833fc54d389c0058f
+    digest: sha256:48e44b6405be4cad97c253216d82dbf36f822efbff3fe468038e7df3e74d5ef2


### PR DESCRIPTION
Automated digest bump from devland-editor-agent CI.

Digest: sha256:48e44b6405be4cad97c253216d82dbf36f822efbff3fe468038e7df3e74d5ef2
Source: https://github.com/PixelJonas/devland-editor-agent/commit/7b8632edc77ad3bd7821a2dc50cc50a954f3e95e