### PR TITLE
chore(devland): bump image to sha-b30fffa

### DIFF
--- a/components-apps/devland/base/kustomization.yaml
+++ b/components-apps/devland/base/kustomization.yaml
@@ -12,4 +12,4 @@ resources:
 images:
   - name: ghcr.io/pixeljonas/devland-2027
     newName: ghcr.io/pixeljonas/devland-2027
-    digest: sha256:23aa34215bfd861f8c7df13d2ba1ccb618351a52215d7c23f3a592ae461e7699
+    digest: sha256:c0db4553e131f3008c64d5f80792b91b90574d67a7e562a909fdfea22181a8f0


### PR DESCRIPTION
Automated digest bump from devland-dummy CI.

Digest: sha256:c0db4553e131f3008c64d5f80792b91b90574d67a7e562a909fdfea22181a8f0
Source: https://github.com/PixelJonas/devland-2027/commit/b30fffa756d04c34923a81053612a4917a6875ee