### PR TITLE
chore(devland): bump image to sha-8974d99

### DIFF
--- a/components-apps/devland/base/kustomization.yaml
+++ b/components-apps/devland/base/kustomization.yaml
@@ -12,4 +12,4 @@ resources:
 images:
   - name: ghcr.io/pixeljonas/devland-2027
     newName: ghcr.io/pixeljonas/devland-2027
-    digest: sha256:c0db4553e131f3008c64d5f80792b91b90574d67a7e562a909fdfea22181a8f0
+    digest: sha256:706eb05a943c133772fa5bae56dfc382bb69c0e118bc3738f796cec17042eebf


### PR DESCRIPTION
Automated digest bump from devland-dummy CI.

Digest: sha256:706eb05a943c133772fa5bae56dfc382bb69c0e118bc3738f796cec17042eebf
Source: https://github.com/PixelJonas/devland-2027/commit/8974d995b6d589b8a0e09bb7c9418cd183cf2d47