### PR TITLE
feat(gha-runners): add scale-set for PixelJonas/tymeslot

### DIFF
--- a/bootstrap/overlays/sakaar/values-infra.yaml
+++ b/bootstrap/overlays/sakaar/values-infra.yaml
@@ -117,6 +117,14 @@ applications:
     source:
       path: components-infra/gha-runner-scale-set-palbuddy/base
 
+  gha-runner-scale-set-tymeslot:
+    annotations:
+      argocd.argoproj.io/sync-wave: "3"
+    destination:
+      namespace: arc-runners
+    source:
+      path: components-infra/gha-runner-scale-set-tymeslot/base
+
   gha-runner-scale-set-taxbuddy:
     annotations:
       argocd.argoproj.io/sync-wave: "3"

--- a/components-infra/gha-runner-scale-set-tymeslot/base/kustomization.yaml
+++ b/components-infra/gha-runner-scale-set-tymeslot/base/kustomization.yaml
@@ -1,0 +1,16 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+commonAnnotations:
+  argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+
+resources:
+  - privileged-clusterrolebinding.yaml
+
+helmCharts:
+  - name: gha-runner-scale-set
+    repo: oci://ghcr.io/actions/actions-runner-controller-charts
+    version: 0.14.2
+    releaseName: arc-runner-set-tymeslot
+    namespace: arc-runners
+    valuesFile: values.yaml

--- a/components-infra/gha-runner-scale-set-tymeslot/base/privileged-clusterrolebinding.yaml
+++ b/components-infra/gha-runner-scale-set-tymeslot/base/privileged-clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: arc-runner-set-tymeslot-privileged
+subjects:
+  - kind: ServiceAccount
+    name: arc-runner-set-tymeslot-gha-rs-no-permission
+    namespace: arc-runners
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:privileged

--- a/components-infra/gha-runner-scale-set-tymeslot/base/values.yaml
+++ b/components-infra/gha-runner-scale-set-tymeslot/base/values.yaml
@@ -1,0 +1,21 @@
+githubConfigUrl: "https://github.com/PixelJonas/tymeslot"
+githubConfigSecret: gha-runners-github-secret
+runnerScaleSetName: "arc-runner-set-tymeslot"
+minRunners: 0
+maxRunners: 2
+controllerServiceAccount:
+  namespace: actions-runner-system
+  name: arc-gha-rs-controller
+containerMode: {}
+template:
+  spec:
+    containers:
+      - name: runner
+        image: ghcr.io/pixeljonas/sakaar-gha-runner:latest
+        command: ["/home/runner/run.sh"]
+        env:
+          - name: RUNNER_ALLOW_RUNASROOT
+            value: "1"
+        securityContext:
+          privileged: true
+          runAsUser: 0


### PR DESCRIPTION
## Summary
- Onboards the new `PixelJonas/tymeslot` fork to the shared self-hosted GHA runner infrastructure on Sakaar, following `onboard-app-to-gha-runners.md`.
- No new namespace/App/credential — reuses the shared `arc-runners` namespace and `gha-runners-github-secret`.
- Needed to build a real linux image with a CalDAV discovery fix for end-to-end testing against the deployed tymeslot-app before it lands upstream.

## Test plan
- [x] `kustomize build --enable-helm components-infra/gha-runner-scale-set-tymeslot/base` renders cleanly
- [x] `kustomize build --enable-helm bootstrap/overlays/sakaar` renders cleanly
- [ ] ArgoCD syncs the new Application and the AutoscalingRunnerSet appears in `arc-runners`
- [ ] A real workflow run in `PixelJonas/tymeslot` registers a runner pod and completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)