### PR TITLE
test(tymeslot): try custom fix image for Nextcloud discovery bug

### DIFF
--- a/components-apps/tymeslot/tymeslot-chart-app.yaml
+++ b/components-apps/tymeslot/tymeslot-chart-app.yaml
@@ -26,8 +26,8 @@ spec:
             containers:
               tymeslot:
                 image:
-                  repository: luka1thb/tymeslot
-                  tag: "1.9.0"
+                  repository: ghcr.io/pixeljonas/tymeslot
+                  tag: "fix-nextcloud-discovery-service-root"
                   pullPolicy: IfNotPresent
                 env:
                   TZ: Europe/Berlin


### PR DESCRIPTION
## Summary
- Temporarily points tymeslot-app at ghcr.io/pixeljonas/tymeslot:fix-nextcloud-discovery-service-root, a custom build of the fork branch containing the Nextcloud CalDAV discovery fix.
- For live end-to-end testing against the real Nextcloud account before opening the upstream PR / reverting to the official image.

## Test plan
- [ ] ArgoCD syncs and the new pod comes up healthy
- [ ] Reconnect the Nextcloud calendar in Tymeslot's UI and confirm calendars actually appear
- [ ] Revert to luka1thb/tymeslot once confirmed (separate follow-up PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)