### PR TITLE
chore(devland): bump image to sha-9c913c7

### DIFF
--- a/components-apps/devland/base/kustomization.yaml
+++ b/components-apps/devland/base/kustomization.yaml
@@ -12,4 +12,4 @@ resources:
 images:
   - name: ghcr.io/pixeljonas/devland-2027
     newName: ghcr.io/pixeljonas/devland-2027
-    digest: sha256:706eb05a943c133772fa5bae56dfc382bb69c0e118bc3738f796cec17042eebf
+    digest: sha256:a8a31a7499f0b1ba9872307f3e51be56ba463d9e4445973027ff63a9eb35c407


### PR DESCRIPTION
Automated digest bump from devland-dummy CI.

Digest: sha256:a8a31a7499f0b1ba9872307f3e51be56ba463d9e4445973027ff63a9eb35c407
Source: https://github.com/PixelJonas/devland-2027/commit/9c913c75397e42503f7b32c51c43d5d0c7835ed3