### PR TITLE
chore(devland): bump image to sha-3fe9370

### DIFF
--- a/components-apps/devland/base/kustomization.yaml
+++ b/components-apps/devland/base/kustomization.yaml
@@ -12,4 +12,4 @@ resources:
 images:
   - name: ghcr.io/pixeljonas/devland-2027
     newName: ghcr.io/pixeljonas/devland-2027
-    digest: sha256:a8a31a7499f0b1ba9872307f3e51be56ba463d9e4445973027ff63a9eb35c407
+    digest: sha256:33556e581c8ec288061be9db766354135b15f53375d3f2fa11e77f3e23bad619


### PR DESCRIPTION
Automated digest bump from devland-dummy CI.

Digest: sha256:33556e581c8ec288061be9db766354135b15f53375d3f2fa11e77f3e23bad619
Source: https://github.com/PixelJonas/devland-2027/commit/3fe93706de4c3048779955370588e5a6771bc907