### PR TITLE
chore(devland): bump image to sha-9cdf879

### DIFF
--- a/components-apps/devland/base/kustomization.yaml
+++ b/components-apps/devland/base/kustomization.yaml
@@ -12,4 +12,4 @@ resources:
 images:
   - name: ghcr.io/pixeljonas/devland-2027
     newName: ghcr.io/pixeljonas/devland-2027
-    digest: sha256:33556e581c8ec288061be9db766354135b15f53375d3f2fa11e77f3e23bad619
+    digest: sha256:4ae067af21838e4cfbd2dbdbf2d87da3743745327a8c5ad1cb0e72eca174b037


### PR DESCRIPTION
Automated digest bump from devland-dummy CI.

Digest: sha256:4ae067af21838e4cfbd2dbdbf2d87da3743745327a8c5ad1cb0e72eca174b037
Source: https://github.com/PixelJonas/devland-2027/commit/9cdf8797cfffd7cea2361fe193b97d3525331742