### PR TITLE
chore(devland-editor-agent): bump image to sha-c1262bb

### DIFF
--- a/components-apps/devland-editor-agent/base/kustomization.yaml
+++ b/components-apps/devland-editor-agent/base/kustomization.yaml
@@ -16,4 +16,4 @@ resources:
 images:
   - name: ghcr.io/pixeljonas/devland-editor-agent
     newName: ghcr.io/pixeljonas/devland-editor-agent
-    digest: sha256:48e44b6405be4cad97c253216d82dbf36f822efbff3fe468038e7df3e74d5ef2
+    digest: sha256:7800a35752a66021f69d28bf1d09dd60525dd7b076bcf479555adad480ca5cd3


### PR DESCRIPTION
Automated digest bump from devland-editor-agent CI.

Digest: sha256:7800a35752a66021f69d28bf1d09dd60525dd7b076bcf479555adad480ca5cd3
Source: https://github.com/PixelJonas/devland-editor-agent/commit/c1262bb7106f02c0c4541406ed6607d3baefb121