### PR TITLE
feat(recordbuddy-worker): durable job state + work dir on models PVC

### DIFF
--- a/components-apps/recordbuddy-worker-de/recordbuddy-worker-de-app.yaml
+++ b/components-apps/recordbuddy-worker-de/recordbuddy-worker-de-app.yaml
@@ -35,6 +35,13 @@ spec:
                   RECORDBUDDY_WORKER_MODEL: Reality-Interface/whisper-large-v3-german-faster-whisper
                   RECORDBUDDY_WORKER_DEVICE: cpu
                   RECORDBUDDY_WORKER_COMPUTE_TYPE: int8
+                  # Durable job state on the models PVC: records survive pod
+                  # restarts (running jobs reload as queued) and results stay
+                  # fetchable for 72h while the async orchestrator is offline.
+                  RECORDBUDDY_WORKER_STATE_DIR: /models/jobs
+                  # Queued/running upload WAVs also on the PVC so a pod
+                  # restart mid-queue doesn't lose them.
+                  RECORDBUDDY_WORKER_WORK_DIR: /models/work
                   RECORDBUDDY_WORKER_SECRET:
                     valueFrom:
                       secretKeyRef:

--- a/components-apps/recordbuddy-worker/recordbuddy-worker-app.yaml
+++ b/components-apps/recordbuddy-worker/recordbuddy-worker-app.yaml
@@ -31,6 +31,13 @@ spec:
                   RECORDBUDDY_WORKER_MODEL: large-v3
                   RECORDBUDDY_WORKER_DEVICE: cpu
                   RECORDBUDDY_WORKER_COMPUTE_TYPE: int8
+                  # Durable job state on the models PVC: records survive pod
+                  # restarts (running jobs reload as queued) and results stay
+                  # fetchable for 72h while the async orchestrator is offline.
+                  RECORDBUDDY_WORKER_STATE_DIR: /models/jobs
+                  # Queued/running upload WAVs also on the PVC so a pod
+                  # restart mid-queue doesn't lose them.
+                  RECORDBUDDY_WORKER_WORK_DIR: /models/work
                   RECORDBUDDY_WORKER_SECRET:
                     valueFrom:
                       secretKeyRef:


### PR DESCRIPTION
Async remote transcribe (recordbuddy@`834a710`, merged from feat/async-remote-transcribe) makes the worker's JobStore persistent when `RECORDBUDDY_WORKER_STATE_DIR` is set. This points it and `RECORDBUDDY_WORKER_WORK_DIR` at the existing models PVC in both worker apps so:

- job records survive pod restarts (running jobs reload as queued)
- results stay fetchable for 72 h while the async orchestrator client is offline
- queued/running upload WAVs survive pod restarts

After merge + ArgoCD sync, both worker pods need a restart to pull the new `:latest` image (push verified: ghcr.io/pixeljonas/recordbuddy-worker sha-834a710 / latest).

Co-authored-by: Kimi Code <noreply@moonshot.ai>