### PR TITLE
fix(tymeslot): move off custom fix image, back to upstream 1.11.0

### DIFF
--- a/components-apps/tymeslot/tymeslot-chart-app.yaml
+++ b/components-apps/tymeslot/tymeslot-chart-app.yaml
@@ -26,8 +26,8 @@ spec:
             containers:
               tymeslot:
                 image:
-                  repository: ghcr.io/pixeljonas/tymeslot
-                  tag: "fix-nextcloud-discovery-service-root"
+                  repository: luka1thb/tymeslot
+                  tag: "1.11.0"
                   pullPolicy: IfNotPresent
                 env:
                   TZ: Europe/Berlin


### PR DESCRIPTION
## Summary
- Our Nextcloud CalDAV discovery fix ([Tymeslot/tymeslot#78](https://github.com/Tymeslot/tymeslot/pull/78)) merged upstream and is included in the just-released `v1.11.0`.
- `docker.io/luka1thb/tymeslot:1.11.0` is published and confirmed to contain the fix commit.
- Switches the deployment off the temporary `ghcr.io/pixeljonas/tymeslot:fix-nextcloud-discovery-service-root` test image back to the official upstream image/tag.

## Test plan
- [ ] ArgoCD syncs and pod comes up healthy on `luka1thb/tymeslot:1.11.0`
- [ ] Nextcloud calendar sync/refresh works as it did on the test image