### PR TITLE
feat(devland-editor-agent): switch primary model to kimi-k3 via LiteLLM

### DIFF
--- a/components-apps/devland-editor-agent/base/deployment.yaml
+++ b/components-apps/devland-editor-agent/base/deployment.yaml
@@ -87,7 +87,7 @@ spec:
             - name: LITELLM_BASE_URL
               value: https://litellm.app.janz.digital/v1
             - name: LITELLM_MODEL_NAME
-              value: claude-sonnet-5
+              value: kimi-k3
             - name: LITELLM_API_KEY
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
## Summary
- Switches devland-editor-agent's `LITELLM_MODEL_NAME` from `claude-sonnet-5` to `kimi-k3`.
- `kimi-k3` is a LiteLLM model alias already reconfigured to route to Moonshot's Kimi K3 (256k context, high reasoning effort) via the Kimi Code subscription endpoint, with an automatic proxy-level fallback to `claude-sonnet-5` on rate-limit/other errors — no app-level fallback logic needed.

## Test plan
- [x] Verified `kimi-k3` chat completions, tool-calling, and streaming work through LiteLLM (manual curl tests against the live proxy).
- [x] Confirmed the `kimi-k3 -> claude-sonnet-5` fallback rule is registered on the proxy.
- [ ] After merge/deploy: confirm pod rollout on Sakaar and run a live end-to-end test against the deployed editor agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)