### PR TITLE
feat(pricing-tool): deploy OpenShift bare-metal pricing tool to Sakaar

### DIFF
--- a/bootstrap/overlays/sakaar/values-apps.yaml
+++ b/bootstrap/overlays/sakaar/values-apps.yaml
@@ -49,3 +49,8 @@ applications:
       argocd.argoproj.io/sync-wave: "300"
     source:
       path: components-apps/recordbuddy-worker-de
+  pricing-tool:
+    annotations:
+      argocd.argoproj.io/sync-wave: "300"
+    source:
+      path: components-apps/pricing-tool

--- a/components-apps/pricing-tool/external-pricing-tool-ghcr-pull.yaml
+++ b/components-apps/pricing-tool/external-pricing-tool-ghcr-pull.yaml
@@ -1,0 +1,23 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: pricing-tool-ghcr-pull-secret
+  namespace: pricing-tool
+  annotations:
+    argocd.argoproj.io/sync-wave: "30"
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: doppler-cluster
+  target:
+    name: pricing-tool-ghcr-pull-secret
+    template:
+      engineVersion: v2
+      type: kubernetes.io/dockerconfigjson
+      data:
+        .dockerconfigjson: |
+          {"auths":{"ghcr.io":{"username":"PixelJonas","password":"{{ .token }}","auth":"{{ printf "PixelJonas:%s" .token | b64enc }}"}}}
+  data:
+    - secretKey: token
+      remoteRef:
+        key: PRICING_TOOL_GHCR_PULL_TOKEN

--- a/components-apps/pricing-tool/kustomization.yaml
+++ b/components-apps/pricing-tool/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - namespace.yaml
+  - external-pricing-tool-ghcr-pull.yaml
+  - pricing-tool-app.yaml

--- a/components-apps/pricing-tool/namespace.yaml
+++ b/components-apps/pricing-tool/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+  name: pricing-tool

--- a/components-apps/pricing-tool/pricing-tool-app.yaml
+++ b/components-apps/pricing-tool/pricing-tool-app.yaml
@@ -1,0 +1,75 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "111"
+  name: pricing-tool-app
+  namespace: openshift-gitops
+spec:
+  destination:
+    namespace: pricing-tool
+    server: "https://kubernetes.default.svc"
+  source:
+    chart: app-template
+    repoURL: https://bjw-s-labs.github.io/helm-charts
+    targetRevision: 5.0.1
+    helm:
+      values: |-
+        defaultPodOptions:
+          imagePullSecrets:
+            - name: pricing-tool-ghcr-pull-secret
+
+        controllers:
+          pricing-tool:
+            containers:
+              pricing-tool:
+                image:
+                  repository: ghcr.io/kounex/openshift-bare-metal-pricing-tool
+                  tag: "1.1.0"
+                  pullPolicy: IfNotPresent
+                env:
+                  SHOW_DISCLAIMER: "true"
+                resources:
+                  requests:
+                    cpu: 10m
+                    memory: 32Mi
+                  limits:
+                    cpu: 200m
+                    memory: 128Mi
+                probes:
+                  liveness:
+                    enabled: true
+                    custom: true
+                    spec:
+                      httpGet:
+                        path: /
+                        port: 8080
+                      initialDelaySeconds: 5
+                      periodSeconds: 30
+                  readiness:
+                    enabled: true
+                    custom: true
+                    spec:
+                      httpGet:
+                        path: /
+                        port: 8080
+                      initialDelaySeconds: 3
+                      periodSeconds: 10
+
+        service:
+          pricing-tool:
+            controller: pricing-tool
+            annotations:
+              tailscale.com/expose: "true"
+              tailscale.com/hostname: "pricing-tool"
+            ports:
+              http:
+                port: 8080
+
+  project: cluster-apps
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true
+    automated:
+      prune: true
+      selfHeal: true


### PR DESCRIPTION
## Summary
- Deploys `ghcr.io/kounex/openshift-bare-metal-pricing-tool:1.1.0` (static PatternFly tool) to a new `pricing-tool` namespace on Sakaar, following the `recordbuddy-worker` pattern (bjw-s app-template chart + GHCR pull secret + Tailscale-only exposure, no public Route).
- Service is annotated `tailscale.com/expose: "true"` / `tailscale.com/hostname: "pricing-tool"` — reachable only on the tailnet, then fronted by the existing Caddy reverse proxy (infra-ops, Doppler-driven, separate change) at `pricing-tool.app.janz.digital` with a Let's Encrypt cert.
- Registers the app in `bootstrap/overlays/sakaar/values-apps.yaml`.

## Test plan
- [ ] `PRICING_TOOL_GHCR_PULL_TOKEN` stored in Doppler `homelab/home` before merge (dedicated PAT — the existing shared `TAXBUDDY_GHCR_PULL_TOKEN` does not have read access to this private package, verified against the GHCR registry API)
- [ ] ArgoCD `Application` `pricing-tool-app` reaches `Synced`/`Healthy`
- [ ] Pod pulls image successfully (no `ImagePullBackOff`)
- [ ] `pricing-tool` device appears on the tailnet and answers on :8080
- [ ] `https://pricing-tool.app.janz.digital` serves the tool with a valid Let's Encrypt cert (after the infra-ops Caddy change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)