### PR TITLE
feat(pricing-tool): add public route with basic-auth sidecar

### DIFF
--- a/components-apps/pricing-tool/external-pricing-tool-basic-auth.yaml
+++ b/components-apps/pricing-tool/external-pricing-tool-basic-auth.yaml
@@ -1,0 +1,17 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: pricing-tool-basic-auth
+  namespace: pricing-tool
+  annotations:
+    argocd.argoproj.io/sync-wave: "30"
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: doppler-cluster
+  target:
+    name: pricing-tool-basic-auth
+  data:
+    - secretKey: .htpasswd
+      remoteRef:
+        key: PRICING_TOOL_BASIC_AUTH_HTPASSWD

--- a/components-apps/pricing-tool/kustomization.yaml
+++ b/components-apps/pricing-tool/kustomization.yaml
@@ -4,4 +4,7 @@ kind: Kustomization
 resources:
   - namespace.yaml
   - external-pricing-tool-ghcr-pull.yaml
+  - external-pricing-tool-basic-auth.yaml
+  - nginx-basic-auth-configmap.yaml
   - pricing-tool-app.yaml
+  - route.yaml

--- a/components-apps/pricing-tool/nginx-basic-auth-configmap.yaml
+++ b/components-apps/pricing-tool/nginx-basic-auth-configmap.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: pricing-tool-nginx-basic-auth
+  namespace: pricing-tool
+data:
+  default.conf: |
+    server {
+        listen 8081;
+        location / {
+            auth_basic "Restricted";
+            auth_basic_user_file /etc/nginx/.htpasswd;
+            proxy_pass http://127.0.0.1:8080;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+    }

--- a/components-apps/pricing-tool/pricing-tool-app.yaml
+++ b/components-apps/pricing-tool/pricing-tool-app.yaml
@@ -55,6 +55,62 @@ spec:
                         port: 8080
                       initialDelaySeconds: 3
                       periodSeconds: 10
+              # Basic-auth reverse-proxy sidecar in front of the app, for the
+              # public Route only (ocp-pricing.janz.cloud). The internal
+              # Tailscale-only Service/port below bypasses this entirely —
+              # it's already gated by tailnet membership.
+              basic-auth:
+                image:
+                  repository: nginxinc/nginx-unprivileged
+                  tag: "1.27-alpine"
+                  pullPolicy: IfNotPresent
+                ports:
+                  - name: authproxy
+                    containerPort: 8081
+                resources:
+                  requests:
+                    cpu: 5m
+                    memory: 16Mi
+                  limits:
+                    cpu: 100m
+                    memory: 64Mi
+                probes:
+                  liveness:
+                    enabled: true
+                    custom: true
+                    spec:
+                      tcpSocket:
+                        port: 8081
+                      initialDelaySeconds: 5
+                      periodSeconds: 30
+                  readiness:
+                    enabled: true
+                    custom: true
+                    spec:
+                      tcpSocket:
+                        port: 8081
+                      initialDelaySeconds: 3
+                      periodSeconds: 10
+
+        persistence:
+          nginx-basic-auth-config:
+            type: configMap
+            name: pricing-tool-nginx-basic-auth
+            advancedMounts:
+              pricing-tool:
+                basic-auth:
+                  - path: /etc/nginx/conf.d/default.conf
+                    subPath: default.conf
+                    readOnly: true
+          htpasswd:
+            type: secret
+            name: pricing-tool-basic-auth
+            advancedMounts:
+              pricing-tool:
+                basic-auth:
+                  - path: /etc/nginx/.htpasswd
+                    subPath: .htpasswd
+                    readOnly: true
 
         service:
           pricing-tool:
@@ -65,6 +121,11 @@ spec:
             ports:
               http:
                 port: 8080
+          pricing-tool-public:
+            controller: pricing-tool
+            ports:
+              authproxy:
+                port: 8081
 
   project: cluster-apps
   syncPolicy:

--- a/components-apps/pricing-tool/route.yaml
+++ b/components-apps/pricing-tool/route.yaml
@@ -1,0 +1,16 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: pricing-tool-public
+  namespace: pricing-tool
+spec:
+  host: ocp-pricing.janz.cloud
+  to:
+    kind: Service
+    name: pricing-tool-public
+    weight: 100
+  port:
+    targetPort: authproxy
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect


### PR DESCRIPTION
## Summary
- Exposes `pricing-tool` publicly at `ocp-pricing.janz.cloud` via the existing Sakaar Apps Cloudflare Tunnel (infra-ops change already applied: new ingress entry + DNS record).
- Adds an `nginx-unprivileged` sidecar container in the same pod, doing HTTP Basic Auth (`auth_basic`) + `proxy_pass` to the app container over localhost — the upstream image is untouched.
- New `pricing-tool-public` Service (port 8081) targets only the sidecar; the existing tailnet-only Service (port 8080, unauthenticated, gated by Tailscale ACL membership) is unaffected.
- New OpenShift Route (`ocp-pricing.janz.cloud`, edge TLS) points at the sidecar service.
- Credential: bcrypt hash stored as `PRICING_TOOL_BASIC_AUTH_HTPASSWD` in Doppler `homelab/home`, synced via a new ExternalSecret — plaintext password never left the user's machine.

## Test plan
- [ ] `PRICING_TOOL_BASIC_AUTH_HTPASSWD` present in Doppler before merge is fully live (pod mounts it; missing key just leaves the ExternalSecret pending, non-destructive)
- [ ] `pricing-tool-public` Service and sidecar container reach `Running`/`Ready`
- [ ] `https://ocp-pricing.janz.cloud` prompts for Basic Auth and rejects wrong/missing credentials (401)
- [ ] Correct credentials reach the app (200, page renders)
- [ ] Existing tailnet path (`pricing-tool.app.janz.digital` via Caddy) still works unauthenticated, unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)