### PR TITLE
fix(pricing-tool): correct Route target Service name

### DIFF
--- a/components-apps/pricing-tool/route.yaml
+++ b/components-apps/pricing-tool/route.yaml
@@ -7,7 +7,7 @@ spec:
   host: ocp-pricing.janz.cloud
   to:
     kind: Service
-    name: pricing-tool-public
+    name: pricing-tool-app-pricing-tool-public
     weight: 100
   port:
     targetPort: authproxy


### PR DESCRIPTION
## Summary
- The bjw-s app-template chart prefixes generated Service names with the Helm release name — the actual Service is `pricing-tool-app-pricing-tool-public`, not the bare `pricing-tool-public` the Route was pointing at.
- Confirmed live: Route showed `Admitted: True` but its target Service didn't exist (`endpoints not found`), so Cloudflare got a 503 for every request to `ocp-pricing.janz.cloud`.

## Test plan
- [ ] `https://ocp-pricing.janz.cloud` returns 401 without credentials
- [ ] Correct credentials return 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)