### PR TITLE
chore(devland-editor-agent): bump image to sha-00e27d8

### DIFF
--- a/components-apps/devland-editor-agent/base/kustomization.yaml
+++ b/components-apps/devland-editor-agent/base/kustomization.yaml
@@ -16,4 +16,4 @@ resources:
 images:
   - name: ghcr.io/pixeljonas/devland-editor-agent
     newName: ghcr.io/pixeljonas/devland-editor-agent
-    digest: sha256:e501a2d9a63e6e54d82b7d711924769a62b7654bc05271046e7c16654cfe047b
+    digest: sha256:441d4609b4ae42a200045df9877c6e2727b864738d1bb8d9da9f2ef347e0f6c3


### PR DESCRIPTION
Automated digest bump from devland-editor-agent CI.

Digest: sha256:441d4609b4ae42a200045df9877c6e2727b864738d1bb8d9da9f2ef347e0f6c3
Source: https://github.com/PixelJonas/devland-editor-agent/commit/00e27d8323db37b5e9c8c0aaac087cd8286b847f