### PR TITLE
chore(devland): bump image to sha-0c7f7b2

### DIFF
--- a/components-apps/devland/base/kustomization.yaml
+++ b/components-apps/devland/base/kustomization.yaml
@@ -12,4 +12,4 @@ resources:
 images:
   - name: ghcr.io/pixeljonas/devland-2027
     newName: ghcr.io/pixeljonas/devland-2027
-    digest: sha256:4ae067af21838e4cfbd2dbdbf2d87da3743745327a8c5ad1cb0e72eca174b037
+    digest: sha256:922985fd5d907679812074a12c14aeb7de59748378f6002aac331a07cb9591c1


### PR DESCRIPTION
Automated digest bump from devland-dummy CI.

Digest: sha256:922985fd5d907679812074a12c14aeb7de59748378f6002aac331a07cb9591c1
Source: https://github.com/PixelJonas/devland-2027/commit/0c7f7b27f1582752344f8d0b573ce933a04888cb