### PR TITLE
chore(devland): bump image to sha-d4d56fd

### DIFF
--- a/components-apps/devland/base/kustomization.yaml
+++ b/components-apps/devland/base/kustomization.yaml
@@ -12,4 +12,4 @@ resources:
 images:
   - name: ghcr.io/pixeljonas/devland-2027
     newName: ghcr.io/pixeljonas/devland-2027
-    digest: sha256:922985fd5d907679812074a12c14aeb7de59748378f6002aac331a07cb9591c1
+    digest: sha256:b31d5d996561f13b899d9d64784d8ace4a055fbba14d97de0a622a424221188a


### PR DESCRIPTION
Automated digest bump from devland-dummy CI.

Digest: sha256:b31d5d996561f13b899d9d64784d8ace4a055fbba14d97de0a622a424221188a
Source: https://github.com/PixelJonas/devland-2027/commit/d4d56fd0c20721edb69f58d21aa2b51a1c17c786