### PR TITLE
fix(tymeslot): restore missing closing quote on image tag

### DIFF
--- a/components-apps/tymeslot/tymeslot-chart-app.yaml
+++ b/components-apps/tymeslot/tymeslot-chart-app.yaml
@@ -27,7 +27,7 @@ spec:
               tymeslot:
                 image:
                   repository: luka1thb/tymeslot
-                  tag: "1.11.1
+                  tag: "1.11.1"
                   pullPolicy: IfNotPresent
                 env:
                   TZ: Europe/Berlin


### PR DESCRIPTION
## Summary
- Renovate PR #314 dropped the closing quote when bumping the image tag to v1.11.1 (`tag: "1.11.1` instead of `tag: "1.11.1"`), which broke Helm template rendering.
- ArgoCD's `tymeslot-app` Application has been stuck on sync status `Unknown` with a cached `ComparisonError` since 2026-08-22. The running pod itself was unaffected (still serving on the last-good image, 1.11.0).

## Fix
Restore the closing quote so the value parses correctly and the intended 1.11.0 → 1.11.1 bump completes.

## Test plan
- [x] `kustomize build components-apps/tymeslot` succeeds locally
- [ ] CI `validate` check passes
- [ ] After merge, confirm ArgoCD `tymeslot-app` returns to `Synced`/`Healthy` and pod rolls to `1.11.1`

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_01Vm48nK178R4QdnZQP6pMmf