### PR TITLE
fix(node-config): label master MCP to activate existing systemReserved fix

### DIFF
--- a/components-infra/node-config/kustomization.yaml
+++ b/components-infra/node-config/kustomization.yaml
@@ -4,3 +4,4 @@ kind: Kustomization
 resources:
   - set-max-pods.yaml
   - increased-reservation.yaml
+  - master-pool-labels.yaml

--- a/components-infra/node-config/master-pool-labels.yaml
+++ b/components-infra/node-config/master-pool-labels.yaml
@@ -1,0 +1,6 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfigPool
+metadata:
+  name: master
+  labels:
+    increased-memory: enabled


### PR DESCRIPTION
## Summary
- `SystemMemoryExceedsReservation` alert firing on altus since 2026-08-25 05:05 UTC — system-slice RSS (~1.14G) exceeds 95% of the kubelet's `systemReserved.memory` budget (default 1Gi). Node is otherwise healthy: 93GB total, ~48GB available, `MemoryPressure: False`.
- Root cause: `components-infra/node-config/increased-reservation.yaml` already defines a `KubeletConfig` raising `systemReserved.memory` to `3Gi`, but it's gated by `machineConfigPoolSelector: increased-memory=enabled` — a label that was never applied to the `master` MachineConfigPool (altus's only pool, single-node cluster). The fix has been sitting inert in git since the original bulk "add all cluster-configuration objects" commit.
- This PR adds `master-pool-labels.yaml`, a minimal partial manifest that labels the `master` MCP without touching any operator-managed fields, so the existing `KubeletConfig` finally applies.

## Impact
Once ArgoCD syncs this, MCO will render a new MachineConfig and roll it out to the node. **Because altus is single-node, this means a brief full-cluster reboot** (all pods down for a few minutes) — expected and approved by jjanz (2026-08-25).

## Test plan
- [x] `kustomize build components-infra/node-config` renders cleanly (verified locally)
- [ ] After merge: confirm ArgoCD syncs `node-config` app, MCP picks up `increased-memory: enabled` label
- [ ] Confirm MCO renders new MachineConfig and node reboots/returns `Ready`
- [ ] Confirm `oc get --raw /api/v1/nodes/altus/proxy/configz` shows `systemReserved.memory: 3Gi` post-reboot
- [ ] Confirm `SystemMemoryExceedsReservation` alert clears in Alertmanager

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vm48nK178R4QdnZQP6pMmf