### PR TITLE
fix(node-config): label master MCP to activate set-max-pods KubeletConfig

### DIFF
--- a/components-infra/node-config/master-pool-labels.yaml
+++ b/components-infra/node-config/master-pool-labels.yaml
@@ -4,3 +4,4 @@ metadata:
   name: master
   labels:
     increased-memory: enabled
+    increased-max-pods: enabled


### PR DESCRIPTION
## Summary
- Same root cause as #356: `set-max-pods`'s `KubeletConfig` (raising `maxPods` to 352 with `autoSizingReserved`/`podsPerCore: 20`) has a `machineConfigPoolSelector` requiring `increased-max-pods: enabled` on the `master` MachineConfigPool. That label was never applied, so `maxPods` has stayed at the OpenShift default (250) since the cluster was built.
- This adds the missing label alongside the existing `increased-memory: enabled` one in `master-pool-labels.yaml`.

## Impact
Once ArgoCD syncs this, MCO will render another new MachineConfig and roll it out to `altus`. Because altus is single-node, this means another brief full-cluster reboot (a few minutes) — same as the previous `increased-memory` rollout. Requested explicitly by jjanz in-session on 2026-08-25.

## Test plan
- [x] `kustomize build components-infra/node-config` renders cleanly (verified locally)
- [ ] After merge: confirm ArgoCD syncs, MCP picks up `increased-max-pods: enabled`
- [ ] Confirm MCO renders new MachineConfig and node reboots/returns `Ready`
- [ ] Confirm live kubelet config (`/api/v1/nodes/altus/proxy/configz`) shows `maxPods: 352`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vm48nK178R4QdnZQP6pMmf