### PR TITLE
fix(lvm-operator): bump lvms-operator channel to stable-4.22

### DIFF
--- a/components-infra/lvm-operator/base/subscription.yaml
+++ b/components-infra/lvm-operator/base/subscription.yaml
@@ -15,7 +15,7 @@ spec:
   # and a total LVM storage outage until bumped (hit for real on Altus's
   # 2026-07-26 reinstall, was still pinned to stable-4.19 against a
   # 4.21.24 cluster). Bump this alongside any OCP minor upgrade.
-  channel: stable-4.21
+  channel: stable-4.22
   installPlanApproval: Automatic
   name: lvms-operator
   source: redhat-operators


### PR DESCRIPTION
## Summary
- Bumps the `lvms-operator` Subscription's `spec.channel` from `stable-4.21` to `stable-4.22`, now that Altus is confirmed on OpenShift 4.22.9.
- Confirmed `stable-4.22` is present in the cluster's OLM catalog before opening this PR: `oc get packagemanifest lvms-operator -o jsonpath='{.status.channels[*].name}'` returned `stable-4.21 stable-4.22`.
- This is the documented per-OCP-minor-upgrade bump called out in the file's own inline comment — the same stale-channel pattern caused a full LVM storage outage on Altus on 2026-07-26 (was pinned to `stable-4.19` against a `4.21.24` cluster).

## Test plan
- [ ] Merge and let ArgoCD sync `lvm-operator`
- [ ] `oc get subscription lvms-operator -n openshift-storage -o wide` shows the new channel and `AtLatestKnown`
- [ ] `oc get csv -n openshift-storage` shows `Succeeded` on the 4.22-aligned build
- [ ] `oc get storageclass lvms-vg1` still present
- [ ] `oc get pv,pvc -A | grep -v Bound` returns nothing (no storage regression)

Not merging this PR — leaving for review per repo convention (opens PRs against home-ops for review rather than auto-merging).

🤖 Generated with [Claude Code](https://claude.com/claude-code)