### PR TITLE
chore: bump origin-cli backup job images from 4.21 to 4.22

### DIFF
--- a/components-apps/nextcloud/bootstrap/job.yaml
+++ b/components-apps/nextcloud/bootstrap/job.yaml
@@ -25,7 +25,7 @@ spec:
             defaultMode: 0755
       containers:
         - name: nextcloud-bootstrap
-          image: quay.io/openshift/origin-cli:4.21
+          image: quay.io/openshift/origin-cli:4.22
           command: ["/bin/bash", "/scripts/bootstrap.sh"]
           env:
             - name: JONAS_PASSWORD

--- a/docs/runbooks/nextcloud-restore.md
+++ b/docs/runbooks/nextcloud-restore.md
@@ -268,7 +268,7 @@ real concern, revisit with either a longer hold or `copyMethod: Snapshot`
         restartPolicy: Never
         containers:
           - name: debug
-            image: quay.io/openshift/origin-cli:4.21
+            image: quay.io/openshift/origin-cli:4.22
             command: ["sleep", "3600"]
             volumeMounts:
               - name: backup

--- a/templates/mariadb-backup/cronjob.yaml
+++ b/templates/mariadb-backup/cronjob.yaml
@@ -27,7 +27,7 @@ spec:
               volumeMounts:
                 - name: backup
                   mountPath: /backup
-              image: quay.io/openshift/origin-cli:4.21
+              image: quay.io/openshift/origin-cli:4.22
               command: ["/bin/bash", "-c"]
               args:
                 - |-

--- a/templates/psql-backup/cronjob.yaml
+++ b/templates/psql-backup/cronjob.yaml
@@ -29,7 +29,7 @@ spec:
               volumeMounts:
                 - name: backup
                   mountPath: /backup
-              image: quay.io/openshift/origin-cli:4.21
+              image: quay.io/openshift/origin-cli:4.22
               command: ["/bin/bash", "-c"]
               args:
                 - |-


### PR DESCRIPTION
## Summary
- Altus is now upgraded to OpenShift 4.22.9 (verified healthy).
- Bumps the hardcoded `quay.io/openshift/origin-cli` image tag from `:4.21` to `:4.22` in the psql-backup and mariadb-backup CronJobs and the Nextcloud bootstrap Job, plus the matching reference in the Nextcloud restore runbook — these jobs run `oc` against the cluster and should track its version.
- Low-risk version-tracking hygiene, no functional/behavioral change.

## Test plan
- [ ] After merge, confirm the next scheduled run of each backup CronJob (psql-backup, mariadb-backup) completes successfully with the new image.
- [ ] Confirm `oc get application -n openshift-gitops -o wide | grep -v "Synced.*Healthy"` is empty post-sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)