### PR TITLE
feat(virt): install OpenShift Virtualization operator (stable channel)

### DIFF
--- a/bootstrap/overlays/local.home/values-infra.yaml
+++ b/bootstrap/overlays/local.home/values-infra.yaml
@@ -37,6 +37,14 @@ applications:
     source:
       path: components-infra/synology-csi
 
+  openshift-virtualization:
+    annotations:
+      argocd.argoproj.io/sync-wave: "2"
+    destination:
+      namespace: openshift-cnv
+    source:
+      path: components-infra/openshift-virtualization/base
+
   external-secrets-doppler:
     annotations:
       argocd.argoproj.io/sync-wave: "2"

--- a/components-infra/openshift-virtualization/base/hyperconverged.yaml
+++ b/components-infra/openshift-virtualization/base/hyperconverged.yaml
@@ -1,0 +1,19 @@
+# Stock HyperConverged CR — deliberately empty spec, no featureGates.
+#
+# Altus previously ran OpenShift Virtualization with an experimental
+# USB-passthrough feature gate enabled (for a Windows 11 KNX-ETS VM). That
+# left the cluster in an unsupported state that blocked a major-version
+# upgrade and forced a full reinstall (see docs/journal in infra-ops:
+# altus-to-sakaar-migration.md). Do not add featureGates here without a
+# documented reason — every one is a fresh way to repeat that incident.
+apiVersion: hco.kubevirt.io/v1beta1
+kind: HyperConverged
+metadata:
+  name: kubevirt-hyperconverged
+  namespace: openshift-cnv
+  annotations:
+    # The HyperConverged CRD is installed by the Subscription's operator,
+    # which hasn't run yet on ArgoCD's first sync — same reasoning as
+    # nmstate's NMState CR in components-infra/nmstate/kustomization.yaml.
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec: {}

--- a/components-infra/openshift-virtualization/base/kustomization.yaml
+++ b/components-infra/openshift-virtualization/base/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+  - github.com/redhat-cop/gitops-catalog/virtualization-operator/base
+  - hyperconverged.yaml


### PR DESCRIPTION
## Summary
- First step of moving the AI coding-agent stack (herdr + Claude Code + Kimi Code) off macOS/asgard onto a Linux VM, per plan in infra-ops.
- Installs `kubevirt-hyperconverged` (stable channel, matches OCP 4.22.9) via the redhat-cop gitops-catalog base — same shape as the existing `nmstate`/`lvm-operator` entries.
- HyperConverged CR spec is intentionally empty — no `featureGates`. An experimental USB-passthrough feature gate is what forced the 2026-07 Altus reinstall the last time this operator ran here.

## Test plan
- [x] `kustomize build components-infra/openshift-virtualization/base` renders cleanly (Namespace, OperatorGroup, Subscription, HyperConverged CR)
- [x] `kustomize build --enable-helm bootstrap/overlays/local.home` confirms the generated ArgoCD `Application` matches sibling apps (sync-wave 2, `cluster-config` project, `openshift-cnv` namespace)
- [ ] After merge: `oc get csv -n openshift-cnv` shows `kubevirt-hyperconverged-operator.v4.22.6` Succeeded, `oc get hyperconverged -n openshift-cnv` shows `Available`
- Follow-up PR (network attachment + the VM itself) is queued behind this one landing and reconciling — CRDs for `VirtualMachine`/`NetworkAttachmentDefinition` don't exist until this operator installs.

Assisted-by: Claude Code
Co-Authored-By: Claude <noreply@anthropic.com>