### PR TITLE
feat(virt): add the knowhere playground VM

### DIFF
--- a/bootstrap/overlays/local.home/values-infra.yaml
+++ b/bootstrap/overlays/local.home/values-infra.yaml
@@ -170,6 +170,15 @@ applications:
     source:
       path: components-infra/restic-rest-server
 
+  knowhere:
+    annotations:
+      argocd.argoproj.io/sync-wave: "40"
+      argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    destination:
+      namespace: knowhere
+    source:
+      path: components-infra/knowhere/base
+
   node-config:
     annotations:
       argocd.argoproj.io/sync-wave: "99"

--- a/components-infra/knowhere/base/datavolume.yaml
+++ b/components-infra/knowhere/base/datavolume.yaml
@@ -1,0 +1,25 @@
+# Ubuntu 24.04 LTS cloud image, deliberately not NixOS: the whole point of
+# this VM is that agents can `curl | sh` and `apt install` arbitrary tools.
+# NixOS has no FHS, so every dynamically-linked binary (including herdr's own
+# installer) needs patchelf/nix-ld first — wrong tool for a playground.
+apiVersion: cdi.kubevirt.io/v1beta1
+kind: DataVolume
+metadata:
+  name: knowhere-rootdisk
+  namespace: knowhere
+  annotations:
+    # The CDI CRDs come from the openshift-virtualization operator
+    # (components-infra/openshift-virtualization), which may not have
+    # reconciled yet on ArgoCD's first pass over this Application.
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  source:
+    http:
+      url: "https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img"
+  storage:
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 300Gi
+    storageClassName: lvms-vg1

--- a/components-infra/knowhere/base/external-secret-cloudinit.yaml
+++ b/components-infra/knowhere/base/external-secret-cloudinit.yaml
@@ -1,0 +1,61 @@
+# Bootstrap-only cloud-init: creates the admin user, authorizes SSH, and
+# installs just enough (qemu-guest-agent, python3) for Ansible to take over.
+# Everything else (herdr, Claude Code, Kimi Code, mounts, tailscale) is
+# configured by stacks/knowhere/ansible/ in infra-ops — this is deliberately
+# thin, matching the "cloud-init does bootstrap, Ansible does configuration"
+# split used nowhere else in this repo (closest precedent is the Ansible-only
+# stacks/nidavellir host_base role).
+#
+# MANUAL STEP: this reads KNOWHERE_SSH_PUBLIC_KEY from the homelab/home
+# Doppler project (the project this cluster's ClusterSecretStore reads from),
+# which does not exist there yet — PERSONAL_SSH_PUBLIC_KEY today only lives
+# in infra-ops/prd, a project this ClusterSecretStore has no access to. Copy
+# the same value across once, e.g. from a machine where the Doppler CLI
+# works (asgard):
+#   VAL=$(doppler secrets get PERSONAL_SSH_PUBLIC_KEY --plain -p infra-ops -c prd -t "$DOPPLER_TOKEN")
+#   doppler secrets set KNOWHERE_SSH_PUBLIC_KEY="$VAL" -p homelab -c home -t "$ASGARD_DOPPLER_HOMELAB_TOKEN"
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: knowhere-cloudinit
+  namespace: knowhere
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: doppler-cluster
+  target:
+    name: knowhere-cloudinit
+    template:
+      engineVersion: v2
+      data:
+        userData: |
+          #cloud-config
+          hostname: knowhere
+          users:
+            - name: jonas
+              groups: [sudo]
+              shell: /bin/bash
+              sudo: "ALL=(ALL) NOPASSWD:ALL"
+              ssh_authorized_keys:
+                - "{{ .sshPublicKey }}"
+          package_update: true
+          packages:
+            - qemu-guest-agent
+            - python3
+          runcmd:
+            - systemctl enable --now qemu-guest-agent
+        networkData: |
+          network:
+            version: 2
+            ethernets:
+              enp1s0:
+                dhcp4: true
+              enp2s0:
+                addresses:
+                  - 10.10.10.51/24
+  data:
+    - secretKey: sshPublicKey
+      remoteRef:
+        key: KNOWHERE_SSH_PUBLIC_KEY

--- a/components-infra/knowhere/base/kustomization.yaml
+++ b/components-infra/knowhere/base/kustomization.yaml
@@ -1,0 +1,6 @@
+resources:
+  - namespace.yaml
+  - network-attachment-definition.yaml
+  - datavolume.yaml
+  - external-secret-cloudinit.yaml
+  - virtualmachine.yaml

--- a/components-infra/knowhere/base/namespace.yaml
+++ b/components-infra/knowhere/base/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: knowhere

--- a/components-infra/knowhere/base/network-attachment-definition.yaml
+++ b/components-infra/knowhere/base/network-attachment-definition.yaml
@@ -1,0 +1,21 @@
+# Binds the VM's second NIC directly to the host's existing "br0" linux
+# bridge (components-infra/nmstate/node-network-configuration-policy.yaml,
+# 10.10.10.50/24 on enp8s0 — the point-to-point link to the NAS). This gives
+# the VM full-speed kernel NFS to the NAS without going through Tailscale's
+# userspace networking, which can't bind a kernel NFS mount.
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: br0
+  namespace: knowhere
+spec:
+  config: |
+    {
+      "cniVersion": "0.3.1",
+      "name": "br0",
+      "type": "cnv-bridge",
+      "bridge": "br0",
+      "macspoofchk": false,
+      "vlan": 0,
+      "preserveDefaultVlan": false
+    }

--- a/components-infra/knowhere/base/virtualmachine.yaml
+++ b/components-infra/knowhere/base/virtualmachine.yaml
@@ -1,0 +1,55 @@
+# 8 vCPU / 32 GiB, measured against altus's live headroom (~15 free cores,
+# ~56 GiB free RAM at time of writing) rather than a guess. Two NICs on
+# purpose: "default" (masquerade, pod network) carries the VM's internet
+# egress; "br0" (multus, bridged to the host's br0) is the NAS-only link and
+# carries no default route, so it can't be used for egress by accident.
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: knowhere
+  namespace: knowhere
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  running: true
+  template:
+    metadata:
+      labels:
+        kubevirt.io/domain: knowhere
+    spec:
+      domain:
+        cpu:
+          cores: 8
+        resources:
+          requests:
+            memory: 32Gi
+          limits:
+            memory: 32Gi
+        devices:
+          rng: {}
+          disks:
+            - name: rootdisk
+              disk:
+                bus: virtio
+            - name: cloudinitdisk
+              disk:
+                bus: virtio
+          interfaces:
+            - name: default
+              masquerade: {}
+            - name: br0
+              bridge: {}
+      networks:
+        - name: default
+          pod: {}
+        - name: br0
+          multus:
+            networkName: br0
+      volumes:
+        - name: rootdisk
+          dataVolume:
+            name: knowhere-rootdisk
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            secretRef:
+              name: knowhere-cloudinit


### PR DESCRIPTION
Stacked on #360 — merge that first and let it reconcile (`oc get hyperconverged -n openshift-cnv` → `Available`) before merging this one. The `VirtualMachine`/`DataVolume`/`NetworkAttachmentDefinition` CRDs don't exist until the operator installs.

## Summary
- Ubuntu 24.04 VM (8 vCPU / 32 GiB RAM / 300 GiB on `lvms-vg1`), sized against altus's live measured headroom (~15 free cores, ~56 GiB free RAM, ~3.1 TB free thin pool) rather than a guess.
- Two NICs: `masquerade` on the pod network for internet egress; a second NIC bridged to the existing `br0` (10.10.10.0/24 — the NAS's direct link, already used by `synology-nfs-storage`) with a static `10.10.10.51/24` and no default route, so NFS traffic can't be mixed up with egress.
- `cloud-init` is bootstrap-only: creates the admin user, authorizes SSH, installs `qemu-guest-agent` + `python3`. Everything else (herdr, Claude Code, Kimi Code, mounts, Tailscale) is a follow-up Ansible role in `infra-ops` (`stacks/knowhere/ansible/`), not yet written.
- Guest OS is deliberately Ubuntu, not NixOS — the whole point of this VM is that agents can `curl | sh` / `apt install` arbitrary tools, and NixOS's lack of an FHS fights that (every dynamically-linked binary, including herdr's own installer, needs `patchelf`/`nix-ld` first).

## ⚠️ Manual step required before this syncs cleanly
`KNOWHERE_SSH_PUBLIC_KEY` needs to exist in the **homelab/home** Doppler project (this cluster's `doppler-cluster` `ClusterSecretStore` only reads from there). Today the equivalent value only lives in **infra-ops/prd** as `PERSONAL_SSH_PUBLIC_KEY`. I couldn't copy it across myself — this machine's local `doppler` CLI is hitting `Unable to retrieve value from system keyring` (`exit status 36`) on every `secrets get`/`secrets set`/`configure unset`, unrelated to this task. From a machine where the CLI works (e.g. asgard):
```
VAL=$(doppler secrets get PERSONAL_SSH_PUBLIC_KEY --plain -p infra-ops -c prd -t "$DOPPLER_TOKEN")
doppler secrets set KNOWHERE_SSH_PUBLIC_KEY="$VAL" -p homelab -c home -t "$ASGARD_DOPPLER_HOMELAB_TOKEN"
```
Until that key exists, the `ExternalSecret` will sit in `SecretSyncedError`.

## Test plan
- [x] `kustomize build components-infra/knowhere/base` renders cleanly
- [x] `kustomize build --enable-helm bootstrap/overlays/local.home` confirms the generated `Application` (sync-wave 40, `SkipDryRunOnMissingResource`, `knowhere` namespace)
- [ ] After the manual Doppler step + merge: `oc get vm,vmi -n knowhere` → `Running`; `virtctl console knowhere` reaches a shell
- [ ] Confirm `10.10.10.51` is reachable from the NAS's storage VLAN and NFS mounts work once the Ansible layer lands

Assisted-by: Claude Code
Co-Authored-By: Claude <noreply@anthropic.com>