### PR TITLE
fix(knowhere): add explicit sync-waves so the Secret precedes the VM

### DIFF
--- a/components-infra/knowhere/base/datavolume.yaml
+++ b/components-infra/knowhere/base/datavolume.yaml
@@ -12,6 +12,7 @@ metadata:
     # (components-infra/openshift-virtualization), which may not have
     # reconciled yet on ArgoCD's first pass over this Application.
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "0"
 spec:
   source:
     http:

--- a/components-infra/knowhere/base/external-secret-cloudinit.yaml
+++ b/components-infra/knowhere/base/external-secret-cloudinit.yaml
@@ -6,21 +6,17 @@
 # split used nowhere else in this repo (closest precedent is the Ansible-only
 # stacks/nidavellir host_base role).
 #
-# MANUAL STEP: this reads KNOWHERE_SSH_PUBLIC_KEY from the homelab/home
-# Doppler project (the project this cluster's ClusterSecretStore reads from),
-# which does not exist there yet — PERSONAL_SSH_PUBLIC_KEY today only lives
-# in infra-ops/prd, a project this ClusterSecretStore has no access to. Copy
-# the same value across once, e.g. from a machine where the Doppler CLI
-# works (asgard):
-#   VAL=$(doppler secrets get PERSONAL_SSH_PUBLIC_KEY --plain -p infra-ops -c prd -t "$DOPPLER_TOKEN")
-#   doppler secrets set KNOWHERE_SSH_PUBLIC_KEY="$VAL" -p homelab -c home -t "$ASGARD_DOPPLER_HOMELAB_TOKEN"
+# KNOWHERE_SSH_PUBLIC_KEY lives in the homelab/home Doppler project (the
+# project this cluster's ClusterSecretStore reads from) — copied there from
+# PERSONAL_SSH_PUBLIC_KEY in infra-ops/prd, a project this ClusterSecretStore
+# has no access to.
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: knowhere-cloudinit
   namespace: knowhere
   annotations:
-    argocd.argoproj.io/sync-wave: "1"
+    argocd.argoproj.io/sync-wave: "0"
 spec:
   secretStoreRef:
     kind: ClusterSecretStore

--- a/components-infra/knowhere/base/namespace.yaml
+++ b/components-infra/knowhere/base/namespace.yaml
@@ -2,3 +2,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: knowhere
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"

--- a/components-infra/knowhere/base/network-attachment-definition.yaml
+++ b/components-infra/knowhere/base/network-attachment-definition.yaml
@@ -8,6 +8,8 @@ kind: NetworkAttachmentDefinition
 metadata:
   name: br0
   namespace: knowhere
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
 spec:
   config: |
     {

--- a/components-infra/knowhere/base/virtualmachine.yaml
+++ b/components-infra/knowhere/base/virtualmachine.yaml
@@ -10,6 +10,11 @@ metadata:
   namespace: knowhere
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    # Must sync after the cloudinit Secret (created by the ExternalSecret,
+    # wave "0") exists — the VM's cloudInitNoCloud volume references it by
+    # name, and ArgoCD applying this before the Secret exists just means the
+    # VM starts with no cloud-init data rather than failing loudly.
+    argocd.argoproj.io/sync-wave: "1"
 spec:
   running: true
   template:


### PR DESCRIPTION
Fixes a real deadlock hit live on the cluster after merging #362: the ExternalSecret was pinned at `sync-wave: "1"` but the VM/DataVolume/NAD had no explicit wave (defaulting to `"0"`), so ArgoCD synced the VM *before* the cloudinit Secret existed and stalled — which in turn meant the ExternalSecret's own later wave never got a turn to run.

`Namespace(-1) -> Secret/DataVolume/NAD(0) -> VM(1)`

Assisted-by: Claude Code
Co-Authored-By: Claude <noreply@anthropic.com>