### PR TITLE
fix(knowhere): add networkDataSecretRef so the br0 NIC actually gets its IP

### DIFF
--- a/components-infra/knowhere/base/virtualmachine.yaml
+++ b/components-infra/knowhere/base/virtualmachine.yaml
@@ -56,5 +56,17 @@ spec:
             name: knowhere-rootdisk
         - name: cloudinitdisk
           cloudInitNoCloud:
+            # `secretRef` only maps to KubeVirt's userDataSecretRef — it does
+            # NOT also pull `networkData` from the same secret, despite both
+            # keys living in one Secret here. A separate networkDataSecretRef
+            # (same secret) is required or the second NIC's static IP is
+            # silently dropped: the seed ISO ends up with only user-data/
+            # meta-data, no network-config, and cloud-init falls back to its
+            # own single-NIC DHCP-only generated config. Confirmed live
+            # 2026-08-26 — enp2s0 came up link-up but administratively down,
+            # "unmanaged" per `netplan status`, with no network-config file
+            # in the seed ISO at all.
             secretRef:
+              name: knowhere-cloudinit
+            networkDataSecretRef:
               name: knowhere-cloudinit


### PR DESCRIPTION
Confirmed live via \`virtctl console\`/SSH once #362's ordering issue cleared: the VM boots fine, cloud-init's user-data works completely (user, SSH key, packages, sshd all correct — SSH already tested and working over the pod network), but the second NIC (\`enp2s0\`, bridged to \`br0\`) never got its static \`10.10.10.51/24\`.

Root cause: \`cloudInitNoCloud.secretRef\` maps only to KubeVirt's \`userDataSecretRef\` — it does not also pull \`networkData\` from that same Secret, despite both keys living there. The seed ISO ended up with only \`user-data\`/\`meta-data\`, no \`network-config\` file at all, so cloud-init fell back to its own single-NIC DHCP-only generated netplan. \`netplan status\` showed \`enp2s0\` as link-up but administratively \`DOWN\`, \`unmanaged\`.

Fix: add a separate \`networkDataSecretRef\` pointing at the same Secret. No changes needed to the Secret/ExternalSecret itself.

## Test plan
- [x] \`kustomize build\` renders both secretRef fields correctly
- [ ] After merge: \`netplan status enp2s0\` shows the static IP; \`ping 10.10.10.51\` succeeds from the altus host

Assisted-by: Claude Code
Co-Authored-By: Claude <noreply@anthropic.com>