### PR TITLE
feat(knowhere): add separate PVC for /home/jonas/projects + VolSync backup

### DIFF
--- a/components-infra/knowhere/base/backup/kustomization.yaml
+++ b/components-infra/knowhere/base/backup/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ./projects

--- a/components-infra/knowhere/base/backup/projects/kustomization.yaml
+++ b/components-infra/knowhere/base/backup/projects/kustomization.yaml
@@ -1,0 +1,26 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# In-cluster restic REST server only — no Backblaze B2 template here.
+# Project data on this dev-playground VM is deliberately not offsited: B2 is
+# reserved for mission-critical data, and this is reprovisionable dev state
+# with its own git remotes as the real disaster-recovery story.
+namePrefix: projects-
+namespace: knowhere
+
+resources:
+  - ../../../../../templates/volsync/rest
+
+patches:
+  - target:
+      group: volsync.backube
+      version: v1alpha1
+      kind: ReplicationSource
+      name: backup
+    path: local.yaml
+  - target:
+      group: external-secrets.io
+      version: v1
+      kind: ExternalSecret
+      name: external-restic-config
+    path: local-secret.yaml

--- a/components-infra/knowhere/base/backup/projects/local-secret.yaml
+++ b/components-infra/knowhere/base/backup/projects/local-secret.yaml
@@ -1,0 +1,6 @@
+- op: replace
+  path: /spec/target/name
+  value: restic-config-projects
+- op: replace
+  path: /spec/data/0/remoteRef/key
+  value: KNOWHERE_PROJECTS_REST_REPO_LOCAL

--- a/components-infra/knowhere/base/backup/projects/local.yaml
+++ b/components-infra/knowhere/base/backup/projects/local.yaml
@@ -1,0 +1,6 @@
+- op: replace
+  path: /spec/sourcePVC
+  value: knowhere-projects
+- op: replace
+  path: /spec/restic/repository
+  value: restic-config-projects

--- a/components-infra/knowhere/base/datavolume-projects.yaml
+++ b/components-infra/knowhere/base/datavolume-projects.yaml
@@ -1,0 +1,26 @@
+# Second disk, deliberately separate from knowhere-rootdisk: project data
+# under /home/jonas/projects is the only thing on this VM worth backing up
+# (see backup/projects/), while the OS disk is fully reprovisionable from
+# stacks/knowhere/ansible/playbook.yml in infra-ops and doesn't need it.
+# Blank source — formatted and mounted by the project_disk Ansible role.
+# 120Gi against ~3.1TB free cluster-wide on lvms-vg1 at time of writing;
+# ~22GB of real project data today, sized generously since local NVMe/SSD
+# capacity here is cheap and headroom isn't a constraint.
+apiVersion: cdi.kubevirt.io/v1beta1
+kind: DataVolume
+metadata:
+  name: knowhere-projects
+  namespace: knowhere
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "0"
+spec:
+  source:
+    blank: {}
+  storage:
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 120Gi
+    storageClassName: lvms-vg1

--- a/components-infra/knowhere/base/kustomization.yaml
+++ b/components-infra/knowhere/base/kustomization.yaml
@@ -2,5 +2,7 @@ resources:
   - namespace.yaml
   - network-attachment-definition.yaml
   - datavolume.yaml
+  - datavolume-projects.yaml
   - external-secret-cloudinit.yaml
   - virtualmachine.yaml
+  - ./backup

--- a/components-infra/knowhere/base/virtualmachine.yaml
+++ b/components-infra/knowhere/base/virtualmachine.yaml
@@ -36,6 +36,15 @@ spec:
             - name: rootdisk
               disk:
                 bus: virtio
+            - name: projectsdisk
+              disk:
+                bus: virtio
+              # Explicit serial so the guest gets a stable
+              # /dev/disk/by-id/virtio-projectsdisk path — without this,
+              # KubeVirt doesn't guarantee /dev/vdb stays /dev/vdb across
+              # reboots or future disk additions. Referenced by the
+              # project_disk Ansible role's fstab entry.
+              serial: projectsdisk
             - name: cloudinitdisk
               disk:
                 bus: virtio
@@ -54,6 +63,9 @@ spec:
         - name: rootdisk
           dataVolume:
             name: knowhere-rootdisk
+        - name: projectsdisk
+          dataVolume:
+            name: knowhere-projects
         - name: cloudinitdisk
           cloudInitNoCloud:
             # `secretRef` only maps to KubeVirt's userDataSecretRef — it does


### PR DESCRIPTION
## Summary
- New DataVolume `knowhere-projects` (120Gi, lvms-vg1), attached to the VM as a second virtio disk with explicit `serial: projectsdisk` for a stable `/dev/disk/by-id` path.
- Decouples project data (needs backup) from the OS root disk (fully reprovisionable via infra-ops's Ansible playbook).
- VolSync `ReplicationSource` for the new PVC targets only the in-cluster restic-rest-server (no Backblaze B2) — dev project data, not mission-critical.
- Paired infra-ops change (`project_disk` Ansible role) formats and mounts the disk at `/home/jonas/projects`.

## Test plan
- [x] `kustomize build components-infra/knowhere/base` renders cleanly
- [ ] CI `validate` check passes
- [ ] VM restarted, disk attached and mounted, verified via SSH

Assisted-by: Claude Code

https://claude.ai/code/session_01PjvaXtXComfFqEi1ftykuQ