### PR TITLE
fix(knowhere): force Filesystem volumeMode on the projects DataVolume

### DIFF
--- a/components-infra/knowhere/base/datavolume-projects.yaml
+++ b/components-infra/knowhere/base/datavolume-projects.yaml
@@ -6,6 +6,26 @@
 # 120Gi against ~3.1TB free cluster-wide on lvms-vg1 at time of writing;
 # ~22GB of real project data today, sized generously since local NVMe/SSD
 # capacity here is cheap and headroom isn't a constraint.
+#
+# Explicit volumeMode: Filesystem — CDI otherwise defaults DataVolumes on
+# lvms-vg1 (TopoLVM, which advertises block support) to Block mode, same as
+# knowhere-rootdisk. That's fine for a disk only KubeVirt itself ever
+# touches, but VolSync's restic mover (see backup/projects/) bind-mounts the
+# source PVC via a plain volumeMount, which requires Filesystem mode —
+# confirmed live: a Block-mode knowhere-projects PVC (and the cache PVC
+# VolSync derives from it) made the mover pod fail immediately with
+# "volume ... has volumeMode Block, but is specified in volumeMounts".
+# KubeVirt mounts a Filesystem-mode PVC's disk.img transparently either way,
+# so this has no effect on the VM side.
+#
+# One-time provisioning quirk seen when this DataVolume was first created:
+# CDI's blank-image populator pod (running under the namespace's default
+# dynamic SCC) left disk.img as owner 107 / group <namespace-scc-gid> —
+# virt-launcher's fixed kubevirt-controller SCC runs qemu as uid:gid 107:107,
+# and the group mismatch caused libvirt to fail with "Cannot access storage
+# file ...: Permission denied" on first boot. Fixed once by hand
+# (`chown 107:107 disk.img` via a temporary debug pod mounting the PVC).
+# Only matters again if this DataVolume is ever deleted and recreated.
 apiVersion: cdi.kubevirt.io/v1beta1
 kind: DataVolume
 metadata:
@@ -20,6 +40,7 @@ spec:
   storage:
     accessModes:
       - ReadWriteOnce
+    volumeMode: Filesystem
     resources:
       requests:
         storage: 120Gi


### PR DESCRIPTION
## Summary
- Follow-up to #365: CDI defaults DataVolumes on `lvms-vg1` to Block mode, which broke the VolSync restic mover (needs a Filesystem-mode bind mount). Adds explicit `volumeMode: Filesystem`.
- Documents a one-time disk.img ownership fix applied by hand after this change (CDI's populator pod left it owned by a group virt-launcher's fixed uid:gid 107:107 can't access).
- Live cluster state already matches this file (applied directly to unblock the VM, which was down); this brings git back in sync so ArgoCD stops reporting drift.

## Test plan
- [x] Live-verified: VM boots, disk mounted, VolSync backup completed successfully
- [ ] CI `validate` check passes

Assisted-by: Claude Code

https://claude.ai/code/session_01PjvaXtXComfFqEi1ftykuQ