### PR TITLE
feat(knowhere): add OVN bridge-mapping NNCP for a LAN-facing NIC (stage 1/3)

### DIFF
--- a/components-infra/nmstate/kustomization.yaml
+++ b/components-infra/nmstate/kustomization.yaml
@@ -1,6 +1,7 @@
 resources:
   - github.com/redhat-cop/gitops-catalog/nmstate/aggregate/overlays/default
   - node-network-configuration-policy.yaml
+  - node-network-configuration-policy-knowhere-lan.yaml
 
 patches:
   - patch: |-

--- a/components-infra/nmstate/node-network-configuration-policy-knowhere-lan.yaml
+++ b/components-infra/nmstate/node-network-configuration-policy-knowhere-lan.yaml
@@ -1,0 +1,22 @@
+# Maps a new OVN "localnet" physical-network name onto the node's EXISTING
+# br-ex OVS bridge (the same bridge OVN-Kubernetes already uses for the
+# node's own LAN uplink via enp4s0). This does NOT create/modify any
+# interface, and does NOT touch br-ex's own ports/IP — it only adds one
+# `knowhere-lan:br-ex` entry to the OVS `external_ids:ovn-bridge-mappings`
+# string, alongside OVN-Kubernetes's own pre-existing `physnet:br-ex` entry
+# (confirmed additive/per-entry, not a whole-string replace).
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: knowhere-lan-bridge-mapping
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  nodeSelector:
+    kubernetes.io/hostname: altus
+  desiredState:
+    ovn:
+      bridge-mappings:
+        - localnet: knowhere-lan
+          bridge: br-ex
+          state: present


### PR DESCRIPTION
## Summary
Stage 1 of 3 for giving `knowhere` a real LAN-facing IP without a new physical NIC or cable run (altus's spare `eno1` can't be cabled — attic-to-office run doesn't exist, dedicated switch not wanted unless truly necessary).

Adds a `NodeNetworkConfigurationPolicy` mapping a new OVN localnet physical-network name (`knowhere-lan`) onto the existing `br-ex` bridge. This only adds one entry to OVS's `ovn-bridge-mappings` external-id, alongside OVN-Kubernetes's own pre-existing `physnet:br-ex` entry — confirmed additive/per-entry, not a whole-string replace. Does not touch `br-ex`'s own interfaces, ports, or IP.

Stages 2 (`ClusterUserDefinedNetwork`) and 3 (VM interface + cloud-init) follow in separate PRs once this is confirmed live and the cluster's own reachability (this is a single-node cluster, `br-ex` also carries API server traffic) is verified stable.

## Test plan
- [ ] `oc get nncp knowhere-lan-bridge-mapping` → `Available`/`SuccessfullyConfigured`
- [ ] `oc debug node/altus -- chroot /host ovs-vsctl get Open_vSwitch . external_ids` → confirms both `physnet:br-ex` and `knowhere-lan:br-ex` present
- [ ] Fresh `oc get nodes`/`oc whoami` from a new session → API server still reachable
- [ ] No disruption to any other altus workload

🤖 Generated with [Claude Code](https://claude.com/claude-code)