### PR TITLE
feat(knowhere): add ClusterUserDefinedNetwork for the LAN localnet (stage 2/3)

### DIFF
--- a/components-infra/knowhere/base/cluster-user-defined-network.yaml
+++ b/components-infra/knowhere/base/cluster-user-defined-network.yaml
@@ -1,0 +1,29 @@
+# Cluster-scoped: OVN-Kubernetes localnet topologies can only be declared at
+# CUDN scope on this cluster version (namespaced UserDefinedNetwork's spec
+# only supports Layer2/Layer3, confirmed via `oc explain
+# userdefinednetwork.spec`). Scoped to just the `knowhere` namespace via
+# namespaceSelector.
+#
+# The CUDN controller auto-generates a NetworkAttachmentDefinition named
+# `knowhere-lan-net` inside every namespace the selector matches — it is not
+# hand-written here.
+apiVersion: k8s.ovn.org/v1
+kind: ClusterUserDefinedNetwork
+metadata:
+  name: knowhere-lan-net
+spec:
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: knowhere
+  network:
+    topology: Localnet
+    localnet:
+      role: Secondary
+      # Must exactly match the NNCP's ovn.bridge-mappings[].localnet value
+      # (node-network-configuration-policy-knowhere-lan.yaml, ../nmstate/).
+      physicalNetworkName: knowhere-lan
+      # The home LAN's UniFi DHCP server is the IPAM source — OVN-Kubernetes
+      # must not also hand out an address here, or the two IPAM sources
+      # fight.
+      ipam:
+        mode: Disabled

--- a/components-infra/knowhere/base/kustomization.yaml
+++ b/components-infra/knowhere/base/kustomization.yaml
@@ -1,6 +1,7 @@
 resources:
   - namespace.yaml
   - network-attachment-definition.yaml
+  - cluster-user-defined-network.yaml
   - datavolume.yaml
   - datavolume-projects.yaml
   - external-secret-cloudinit.yaml


### PR DESCRIPTION
## Summary
Stage 2 of 3 (see #367 for stage 1). Adds a `ClusterUserDefinedNetwork` with `topology: Localnet`, scoped to the `knowhere` namespace, referencing the `knowhere-lan` physical-network mapping added in stage 1. The CUDN controller auto-generates a `NetworkAttachmentDefinition` (`knowhere-lan-net`) in-namespace — not hand-written here.

IPAM disabled: the home LAN's UniFi DHCP server will be the IP source once the VM's NIC is added in stage 3.

## Test plan
- [ ] `oc get clusteruserdefinednetwork knowhere-lan-net` → ready/synced condition
- [ ] `oc get network-attachment-definitions -n knowhere` → confirms `knowhere-lan-net` NAD auto-generated
- [ ] No disruption to any other altus workload or the knowhere VM (not yet referencing this network)

🤖 Generated with [Claude Code](https://claude.com/claude-code)