### PR TITLE
feat(knowhere): add third NIC riding the LAN localnet (stage 3/3)

### DIFF
--- a/components-infra/knowhere/base/external-secret-cloudinit.yaml
+++ b/components-infra/knowhere/base/external-secret-cloudinit.yaml
@@ -51,6 +51,10 @@ spec:
               enp2s0:
                 addresses:
                   - 10.10.10.51/24
+              enp3s0:
+                dhcp4: true
+                dhcp4-overrides:
+                  use-routes: false
   data:
     - secretKey: sshPublicKey
       remoteRef:

--- a/components-infra/knowhere/base/virtualmachine.yaml
+++ b/components-infra/knowhere/base/virtualmachine.yaml
@@ -1,8 +1,11 @@
 # 8 vCPU / 32 GiB, measured against altus's live headroom (~15 free cores,
-# ~56 GiB free RAM at time of writing) rather than a guess. Two NICs on
+# ~56 GiB free RAM at time of writing) rather than a guess. Three NICs on
 # purpose: "default" (masquerade, pod network) carries the VM's internet
 # egress; "br0" (multus, bridged to the host's br0) is the NAS-only link and
-# carries no default route, so it can't be used for egress by accident.
+# carries no default route, so it can't be used for egress by accident;
+# "lan" (multus, riding the OVN localnet knowhere-lan-net onto br-ex) gives
+# a real home-LAN IP via UniFi DHCP, for SSH/mosh access without needing
+# Tailscale running client-side.
 apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 metadata:
@@ -53,12 +56,20 @@ spec:
               masquerade: {}
             - name: br0
               bridge: {}
+            - name: lan
+              bridge: {}
       networks:
         - name: default
           pod: {}
         - name: br0
           multus:
             networkName: br0
+        - name: lan
+          multus:
+            # References the ClusterUserDefinedNetwork's metadata.name — the
+            # CUDN controller auto-generates a same-named NAD in this
+            # namespace (../cluster-user-defined-network.yaml).
+            networkName: knowhere-lan-net
       volumes:
         - name: rootdisk
           dataVolume:


### PR DESCRIPTION
## Summary
Stage 3 of 3 (see #367, #368). Adds a third VM interface ("lan") referencing the `knowhere-lan-net` NAD, plus the matching `enp3s0` DHCP netplan entry (no default route, same pattern as `br0`).

**Requires a VM restart** — KubeVirt doesn't hot-plug Multus bridge interfaces onto a running domain. Will restart immediately after merge/sync.

## Test plan
- [ ] `oc get vmi knowhere -o yaml` shows 3 interfaces after restart, new one with an auto-assigned MAC (kubemacpool)
- [ ] VMI returns to `Running`/Ready with all three NICs, not just the new one
- [ ] Guest confirms DHCP lease on the LAN subnet, no unexpected second default route
- [ ] LAN reachability (ping/SSH) confirmed from another device
- [ ] Existing `default` and `br0` NICs still functional post-restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)