### PR TITLE
fix(knowhere): use Snapshot copyMethod for projects backup, not Direct

### DIFF
--- a/components-infra/knowhere/base/backup/projects/local.yaml
+++ b/components-infra/knowhere/base/backup/projects/local.yaml
@@ -4,3 +4,15 @@
 - op: replace
   path: /spec/restic/repository
   value: restic-config-projects
+# copyMethod: Direct mounts the live source PVC into the backup mover pod.
+# On this VM, that PVC is also the live-attached KubeVirt projectsdisk — the
+# mover pod's SELinux relabel on mount left the file's category mismatched
+# against the running virt-launcher process after the mover exited, which
+# broke virt-launcher's periodic disk-capacity check and paused the VM in a
+# loop (2026-08-28). Snapshot avoids ever touching the live PVC's files.
+- op: replace
+  path: /spec/restic/copyMethod
+  value: Snapshot
+- op: add
+  path: /spec/restic/volumeSnapshotClassName
+  value: lvms-vg1


### PR DESCRIPTION
## Summary
- `copyMethod: Direct` on knowhere's projects `ReplicationSource` mounts the live source PVC directly into VolSync's backup mover pod
- That PVC is also the live-attached KubeVirt `projectsdisk` — the mover pod's SELinux relabel-on-mount left the disk image's category mismatched against the running virt-launcher process after the mover pod exited
- Undetected until virt-launcher's periodic disk-capacity check did a fresh `stat()`/`open()` on the file, hit the SELinux denial, and triggered a QEMU image-lock failure that paused the VM in a repeating pause/unpause loop for ~2 hours (2026-08-28)
- Switches to `copyMethod: Snapshot` (backs up a point-in-time `VolumeSnapshot` instead, never touching the live PVC's files) using the existing `lvms-vg1` `VolumeSnapshotClass`, already used elsewhere on this cluster

## Root cause (live-diagnosed)
```
VMI condition: reason: PausedIOError, message: "VMI was paused, low-level IO error detected"
virt-launcher log: "Failed to get total usable space, using disk capacity instead" reason: permission denied
virt-launcher log: "internal error: unable to execute QEMU command 'block_resize': Failed to lock byte 103"
```
Confirmed via direct SELinux context comparison on the node: the volume's `disk.img` was labeled `system_u:object_r:container_file_t:s0:c2,c33` while the running `qemu-kvm`/`virt-launcher` process ran under `system_u:system_r:container_t:s0:c332,c740` — a stale category left over from the prior night's `Direct`-copyMethod backup mover pod mounting the same PVC.

Immediate fix applied live (not in this PR): `chcon -l s0:c332,c740` on the volume to relabel it back to match the running process, unblocking the loop without a VM restart. This PR prevents recurrence at the next scheduled backup (05:00 UTC daily).

## Test plan
- [x] `kustomize build components-infra/knowhere/base/backup/projects` renders `copyMethod: Snapshot` + `volumeSnapshotClassName: lvms-vg1` correctly
- [x] Confirmed `VolumeSnapshotClass/lvms-vg1` (driver `topolvm.io`) and the CSI snapshot-controller both already exist and are running on this cluster
- [ ] Confirm tomorrow's scheduled backup (2026-08-29 05:00 UTC) completes successfully via Snapshot and does not recur the pause loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)