### PR TITLE
fix(gitea): allow dl.gitea.com/charts in cluster-apps AppProject

### DIFF
--- a/bootstrap/overlays/local.home/values-apps.yaml
+++ b/bootstrap/overlays/local.home/values-apps.yaml
@@ -26,6 +26,7 @@ projects:
       - https://github.com/redhat-cop/gitops-catalog
       - https://bjw-s-labs.github.io/helm-charts
       - https://nextcloud.github.io/helm/
+      - https://dl.gitea.com/charts
     destinations: |
       - namespace: '*'
         server: https://kubernetes.default.svc


### PR DESCRIPTION
## Summary
- Follow-up to #376. Live sync revealed \`gitea-app\`/\`gitea-actions-app\` failing with \`InvalidSpecError: application repo https://dl.gitea.com/charts is not permitted in project 'cluster-apps'\` — Gitea is the first app in this repo to source a Helm chart directly from its own repo rather than through the shared \`bjw-s-labs.github.io/helm-charts\`.
- Adds \`https://dl.gitea.com/charts\` to the \`cluster-apps\` AppProject's \`sourceRepos\` allowlist. Covers both Gitea Applications (same repo URL).

## Test plan
- [x] \`kustomize build --enable-helm bootstrap/overlays/local.home\` renders the AppProject with the new sourceRepo present
- [ ] Post-merge: \`gitea-app\`/\`gitea-actions-app\` sync succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)